### PR TITLE
Add python 3.4 to allowed_failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 python:
   - "2.7"
   - "3.4"
+matrix:
+  allow_failures:
+    - python: "3.4"
 install:
   - "pip install . --use-mirrors"
 script: "python setup.py test"


### PR DESCRIPTION
So it is more obvious the repo isnt supported on 3.4
