### PR TITLE
Add extra fields to JSON log

### DIFF
--- a/performanceplatform/collector/logging_setup.py
+++ b/performanceplatform/collector/logging_setup.py
@@ -17,7 +17,7 @@ def get_json_log_handler(path, app_name, json_fields):
     handler = logging.FileHandler(path)
     formatter = LogstashFormatter()
     formatter.defaults['@tags'] = ['collector', app_name]
-    formatter.defaults.update(json_fields)
+    formatter.defaults['@fields'] = json_fields
     handler.setFormatter(formatter)
     return handler
 

--- a/performanceplatform/collector/main.py
+++ b/performanceplatform/collector/main.py
@@ -35,10 +35,10 @@ def make_extra_json_fields(args):
     fields to be inserted into JSON logs (logstash_formatter module)
     """
     return {
-        '@data_group': _get_data_group(args.query),
-        '@data_type': _get_data_type(args.query),
-        '@data_group_data_type': _get_data_group_data_type(args.query),
-        '@query': _get_query_params(args.query),
+        'data_group': _get_data_group(args.query),
+        'data_type': _get_data_type(args.query),
+        'data_group_data_type': _get_data_group_data_type(args.query),
+        'query': _get_query_params(args.query),
     }
 
 


### PR DESCRIPTION
Add the data group/type and a stringified version of the actual query
we're running.

The extra fields in the JSON log message look like this:

```
{
...
 "@fields": {
   "data_group" : "govuk",
   "data_group_data_type" : "govuk/visitors",
   "data_type" : "visitors",
   "query" : "id=ga:56580952 metrics=[u'visitors']"
  ...
  }
}
```

https://www.pivotaltracker.com/story/show/70748012

[#70748012]
