### PR TITLE
Add venv, build and out to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,7 @@
 *.pyc
 *.egg-info
 dist
+build
+out
+venv
 *.egg


### PR DESCRIPTION
if you follow the setup in the readme for source then you get these directories which we don't want to source control changes to
