### PR TITLE
Workaround to stop problem running setup.py test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,11 @@ from setuptools import setup, find_packages
 
 from performanceplatform import collector
 
+# multiprocessing and logging don't get on with each other in Python
+# vesions < 2.7.4. The following unused import is a workaround. See:
+# http://bugs.python.org/issue15881#msg170215
+import multiprocessing
+
 requirements = [
     'requests',
     'pytz==2013d',


### PR DESCRIPTION
multiprocessing and logging don't get on with each other in Python vesion 2.7.3 (but is fixed in 2.7.4). Importing multiprocessing in setup.py is a workaround mentioned in a couple of places online.

See: http://bugs.python.org/issue15881#msg170215
