### PR TITLE
Allow the 'dataType' field to be overriden

### DIFF
--- a/performanceplatform/collector/ga/__init__.py
+++ b/performanceplatform/collector/ga/__init__.py
@@ -12,8 +12,8 @@ def main(credentials, data_set_config, query, options, start_at, end_at):
 
     documents = query_documents_for(
         client, query, options,
-        data_set_config['data-type'], start_at, end_at
-    )
+        options.get('dataType', data_set_config['data-type']),
+        start_at, end_at)
 
     data_set = DataSet.from_config(data_set_config)
     send_data(data_set, documents)


### PR DESCRIPTION
The 'dataType' field in records predates data groups and data types. As
such they don't always match the new world order of data types. It's
fine to change in all cases other than Licensing which is run on
limelight, that we don't really want to touch.
