### PR TITLE
Monitor ga in graphite

### DIFF
--- a/performanceplatform/collector/ga/core.py
+++ b/performanceplatform/collector/ga/core.py
@@ -3,6 +3,7 @@ import json
 import logging
 import re
 from performanceplatform.utils.http_with_backoff import HttpWithBackoff
+from performanceplatform.utils import statsd
 
 from gapy.client import from_private_key, from_secrets_file
 
@@ -16,6 +17,7 @@ def create_client(credentials):
             credentials['CLIENT_SECRETS'],
             storage_path=credentials['STORAGE_PATH'],
             http_client=HttpWithBackoff(),
+            ga_hook=track_ga_api_usage,
         )
     else:
         return from_private_key(
@@ -23,7 +25,12 @@ def create_client(credentials):
             private_key_path=credentials['PRIVATE_KEY'],
             storage_path=credentials['STORAGE_PATH'],
             http_client=HttpWithBackoff(),
+            ga_hook=track_ga_api_usage,
         )
+
+
+def track_ga_api_usage(kwargs):
+    statsd.incr('ga.core.{}.count'.format(kwargs['ids'].replace(':', '')))
 
 
 def query_ga(client, config, start_date, end_date):

--- a/performanceplatform/utils/__init__.py
+++ b/performanceplatform/utils/__init__.py
@@ -1,0 +1,7 @@
+import os
+
+import statsd as _statsd
+
+
+statsd = _statsd.StatsClient(
+    prefix=os.getenv('GOVUK_STATSD_PREFIX', 'pp.apps.collector'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ lxml>=3.2.0
 dshelpers>=1.0.4
 unicodecsv
 requests>=1.2.0
+statsd==3.0


### PR DESCRIPTION
This is required so that we can monitor how close we get to our API limits.
