### PR TITLE
Include README.rst in distribution manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include *.txt
+include README.rst


### PR DESCRIPTION
When installing from PyPI, the command fails with:

```
No such file or directory: '/path/to/performanceplatform-collector/README.rst'
```

I think this is because the README isn't distributed with the module because it's not included in the manifest file.

Fixes #52?
