### PR TITLE
Add a path to the query file to the json object

### DIFF
--- a/performanceplatform/collector/arguments.py
+++ b/performanceplatform/collector/arguments.py
@@ -9,7 +9,9 @@ def parse_args(name="", args=None):
     Returns an argparse.Namespace with 'config' and 'query' options"""
     def _load_json_file(path):
         with open(path) as f:
-            return json.load(f)
+            json_data = json.load(f)
+            json_data['path_to_query'] = path
+            return json_data
 
     parser = argparse.ArgumentParser(description="%s collector for sending"
                                                  " data to the performance"

--- a/performanceplatform/collector/main.py
+++ b/performanceplatform/collector/main.py
@@ -40,6 +40,7 @@ def make_extra_json_fields(args):
         'data_type': _get_data_type(args.query),
         'data_group_data_type': _get_data_group_data_type(args.query),
         'query': _get_query_params(args.query),
+        'path_to_query': _get_path_to_query(args.query),
     }
 
 
@@ -62,6 +63,10 @@ def _get_query_params(query):
     """
     query_params = OrderedDict(sorted(query['query'].items()))
     return ' '.join(['{}={}'.format(k, v) for k, v in query_params.items()])
+
+
+def _get_path_to_query(query):
+    return query['path_to_config']
 
 
 def main():


### PR DESCRIPTION
The filename is passed in on the command line, but the argument parser 
takes this filename and loads it in as json, which is what is expected through
the codebase. So after arugment parsing the query filename is not known. This
change adds the path of the query file to the json object, so we do not lose
that information. This may not be the best way of keeping track of the filename
of the query however, this PR is meant for comments on this / alternative
approaches
