### PR TITLE
Make performanceplatform a namespace package

### DIFF
--- a/performanceplatform/__init__.py
+++ b/performanceplatform/__init__.py
@@ -1,3 +1,7 @@
 # Namespace package: https://docs.python.org/2/library/pkgutil.html
-from pkgutil import extend_path
-__path__ = extend_path(__path__, __name__)
+try:
+    import pkg_resources
+    pkg_resources.declare_namespace(__name__)
+except ImportError:
+    from pkgutil import extend_path
+    __path__ = extend_path(__path__, __name__)

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ if __name__ == '__main__':
         name='performanceplatform-collector',
         version=_get_version(),
         packages=find_packages(exclude=['test*']),
+        namespace_packages=['performanceplatform'],
 
         # metadata for upload to PyPI
         author=collector.__author__,


### PR DESCRIPTION
Namespace packages allow multiple eggs to live within the same
namespace. This is needed for the performanceplatform package as we need
to extract a performance platform client out into a separate package for
use by the upload app.

http://peak.telecommunity.com/DevCenter/setuptools#namespace-packages
