### PR TITLE
Fix writing compressed requests

### DIFF
--- a/performanceplatform/collector/write.py
+++ b/performanceplatform/collector/write.py
@@ -54,7 +54,7 @@ class DataSet(object):
         if self.dry_run:
             DataSet._log_request('POST', self.url, headers, json_body)
         else:
-            if False and len(json_body) > 2048:
+            if len(json_body) > 2048:
                 # compress the request
                 headers["Content-Encoding"] = "gzip"
                 import gzip
@@ -63,6 +63,7 @@ class DataSet(object):
                 f = gzip.GzipFile(filename='', mode='wb', fileobj=bio)
                 f.write(json_body)
                 f.close()
+                bio.seek(0)
                 json_body = bio
 
             response = requests_with_backoff.post(


### PR DESCRIPTION
Tested with:

```
import performanceplatform.collector.write as write

config = {
 'url':'http://httpbin.org/post',
 'dry_run': False,
 'token': 'not-real',
}

big_string = "x" * 3000

data_set = write.DataSet.from_config(config)

data_set.post({'key': big_string})
```
