### PR TITLE
Fix post deploy so failures cause a deploy failure

### DIFF
--- a/hooks/post_deploy
+++ b/hooks/post_deploy
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -e
+set -o pipefail
 
 PATH_TO_APP="$(pwd)"
 PATH_TO_PYTHON="$PATH_TO_APP/venv/bin/python"


### PR DESCRIPTION
There was an error generating the cronjob that would have been
highlighted if we failed the script when any of the commands failed.
