### PR TITLE
Use logging.basicConfig when logging to console

### DIFF
--- a/performanceplatform/collector/main.py
+++ b/performanceplatform/collector/main.py
@@ -75,8 +75,7 @@ def main():
     entrypoint = args.query['entrypoint']
 
     if args.console_logging:
-        logger = logging.getLogger()
-        logger.setLevel(logging.INFO)
+        logging.basicConfig(level=logging.INFO)
     else:
         logging_for_entrypoint(entrypoint, make_extra_json_fields(args))
 


### PR DESCRIPTION
This fixes the 'No handlers could be found for logger "apiclient.discovery"'
problem.
