### PR TITLE
Update README with details of start and end dates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,9 +52,9 @@ There are also some optional command line arguments you can provide pp-collect::
     When it comes to submitting the gathered data to the Performance Platform it will skip
     making the POST requests and instead log out the url, headers and body to your terminal.
 
-    --start-date
+    --start, --end
     If you want the collector to gather past data, you can specify a start date, e.g.
-    "10-01-2013".
+    "10-01-2013". You must also specify an end date.
 
 Configuration
 -------------


### PR DESCRIPTION
If you specify a start date you must also specify an end date.
In addition, the option should be --start not --start-date.
