### PR TITLE
Make post deploy hook use bash

### DIFF
--- a/hooks/post_deploy
+++ b/hooks/post_deploy
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 set -o pipefail
 


### PR DESCRIPTION
pipefail is not recognised by sh
