### PR TITLE
Convert avgSessionDuration metrics from s to ms

### DIFF
--- a/performanceplatform/collector/ga/core.py
+++ b/performanceplatform/collector/ga/core.py
@@ -131,6 +131,17 @@ def try_number(value):
                      .format(value))
 
 
+def convert_durations(metric):
+    """
+    Convert session duration metrics from seconds to milliseconds.
+    """
+    if metric[0] == 'avgSessionDuration' and metric[1]:
+        new_metric = (metric[0], metric[1] * 1000)
+    else:
+        new_metric = metric
+    return new_metric
+
+
 def build_document(item, data_type,
                    mappings=None, idMapping=None, timespan='week'):
     if data_type is None:
@@ -166,6 +177,7 @@ def build_document(item, data_type,
 
     metrics = [(key, try_number(value))
                for key, value in item["metrics"].items()]
+    metrics = [convert_durations(metric) for metric in metrics]
     return dict(base_properties.items() + dimensions + metrics)
 
 

--- a/tests/performanceplatform/collector/ga/test_core.py
+++ b/tests/performanceplatform/collector/ga/test_core.py
@@ -11,7 +11,8 @@ from nose.tools import (assert_in, assert_not_in, assert_is_instance,
 from performanceplatform.collector.ga.core import \
     query_ga, build_document, data_id, apply_key_mapping, \
     build_document_set, query_for_range, \
-    query_documents_for, map_multi_value_fields
+    query_documents_for, map_multi_value_fields, \
+    convert_durations
 
 from tests.performanceplatform.collector.ga import dt
 
@@ -552,3 +553,20 @@ def test_float_number():
     (doc_0,) = build_document_set(items, "", None, None)
 
     assert_that(doc_0['rate'], is_(23.4))
+
+
+def test_convert_duration():
+    query_0 = ('avgSessionDuration', 400.0)
+    expected_response_0 = ('avgSessionDuration', 400000.0)
+    query_1 = ('avgSessionDuration', None)
+    expected_response_1 = ('avgSessionDuration', None)
+    query_2 = ('uniquePageviews', 400)
+    expected_response_2 = ('uniquePageviews', 400)
+
+    response_0 = convert_durations(query_0)
+    response_1 = convert_durations(query_1)
+    response_2 = convert_durations(query_2)
+
+    assert_that(response_0, is_(expected_response_0))
+    assert_that(response_1, is_(expected_response_1))
+    assert_that(response_2, is_(expected_response_2))


### PR DESCRIPTION
Google Analytics returns avgSessionDuration metrics in seconds, but
everywhere in Backdrop and Spotlight expects duration metrics to be
in milliseconds.

After discussion, we have decided it's best to serve our data up
consistently. So convert avgSessionDuration metrics to ms as
part of collection.

This field is used for the "time taken to complete transaction"
graph.

Clearly it would be better to convert all metrics with a data-type
of type "time", or all metrics named duration, rather than just
looking for this specific metric. However despite much hunting
through Google Analytics API documentation, and a question to
the forums, I still can't establish whether the API uses seconds
consistently or whether this is set on a per-field basis.

So I have erred on the side of caution, and only converted this
field to milliseconds. Our API documentation should state that we
return all time fields in milliseconds.
