### PR TITLE
Apply mappings over whole document

### DIFF
--- a/performanceplatform/collector/ga/core.py
+++ b/performanceplatform/collector/ga/core.py
@@ -171,14 +171,17 @@ def build_document(item, data_type,
         "timeSpan": timespan,
         "dataType": data_type
     }
-    dimensions = apply_key_mapping(
-        mappings,
-        item.get("dimensions", {})).items()
 
     metrics = [(key, try_number(value))
                for key, value in item["metrics"].items()]
     metrics = [convert_durations(metric) for metric in metrics]
-    return dict(base_properties.items() + dimensions + metrics)
+
+    doc = dict(base_properties.items() +
+               item.get("dimensions", {}).items() +
+               metrics)
+    doc = apply_key_mapping(mappings, doc)
+
+    return doc
 
 
 def pretty_print(obj):

--- a/tests/performanceplatform/collector/ga/test_core.py
+++ b/tests/performanceplatform/collector/ga/test_core.py
@@ -250,6 +250,27 @@ def test_map_available_multi_value_fields():
     assert_that(document, is_({'one': 'foo', 'two': 'bar'}))
 
 
+def test_mapping_is_applied_to_whole_document():
+    mappings = {
+        'visits': 'count',
+        'customVarValue1': 'name',
+        'timeSpan': 'period',
+    }
+    gapy_response = {
+        "metrics": {"visits": "12345"},
+        "dimensions": {"customVarValue1": "Jane"},
+        "start_date": date(2013, 4, 1),
+    }
+
+    doc = build_document(gapy_response, "people",  mappings)
+
+    assert_that(doc, has_entries({
+        "count": 12345,
+        "name": "Jane",
+        "period": "week",
+    }))
+
+
 def test_build_document_set():
     def build_gapy_response(visits, name, start_date):
         return {


### PR DESCRIPTION
We should be able to map any of the returned values from GA into a field
with another name. We want to use this to be able to map a GA number at
completion stage into a count of transactions-by-channel.
