### PR TITLE
idMapping should work on any field in document

### DIFF
--- a/performanceplatform/collector/ga/core.py
+++ b/performanceplatform/collector/ga/core.py
@@ -149,25 +149,8 @@ def build_document(item, data_type,
     if mappings is None:
         mappings = {}
 
-    if idMapping is not None:
-        if isinstance(idMapping, list):
-            values_for_id = map(lambda d: item['dimensions'][d], idMapping)
-            value_for_id = "".join(values_for_id)
-        else:
-            value_for_id = item['dimensions'][idMapping]
-
-        (_id, human_id) = value_id(value_for_id)
-    else:
-        (_id, human_id) = data_id(
-            data_type,
-            to_datetime(item["start_date"]),
-            timespan,
-            item.get('dimensions', {}).values())
-
     base_properties = {
-        "_id": _id,
         "_timestamp": to_datetime(item["start_date"]),
-        "humanId": human_id,
         "timeSpan": timespan,
         "dataType": data_type
     }
@@ -180,6 +163,25 @@ def build_document(item, data_type,
                item.get("dimensions", {}).items() +
                metrics)
     doc = apply_key_mapping(mappings, doc)
+
+    if idMapping is not None:
+        if isinstance(idMapping, list):
+            values_for_id = map(lambda d: doc[d], idMapping)
+            print values_for_id
+            value_for_id = "".join(values_for_id)
+        else:
+            value_for_id = doc[idMapping]
+
+        (_id, human_id) = value_id(value_for_id)
+    else:
+        (_id, human_id) = data_id(
+            data_type,
+            to_datetime(item["start_date"]),
+            timespan,
+            item.get('dimensions', {}).values())
+
+    doc['humanId'] = human_id
+    doc['_id'] = _id
 
     return doc
 

--- a/tests/performanceplatform/collector/ga/test_core.py
+++ b/tests/performanceplatform/collector/ga/test_core.py
@@ -332,6 +332,16 @@ def test_if_we_provide_id_field_array_it_is_used():
     eq_(doc["_id"], "MdiBMg==")
 
 
+def test_if_we_provide_id_field_it_uses_the_whole_doc():
+    doc = build_document({"dimensions": {"var": "f"},
+                          "metrics": {"some_metric": 123},
+                          "start_date": date(2014, 2, 19)},
+                         "oo",
+                         idMapping=["var", "dataType"])
+
+    eq_(doc["_id"], "Zm9v")
+
+
 def test_plugin():
 
     input_document = {


### PR DESCRIPTION
Previously idMapping would only work over dimensions returned by the GA
query. We have a requirement to use a field that will only exist on the
document as part of the id. This commit moves the id generation logic to
after the munging of the document then uses fields in the doc rather
than off the item.
