### PR TITLE
Additional items should be added before idMapping

### DIFF
--- a/tests/performanceplatform/collector/ga/test_core.py
+++ b/tests/performanceplatform/collector/ga/test_core.py
@@ -342,6 +342,17 @@ def test_if_we_provide_id_field_it_uses_the_whole_doc():
     eq_(doc["_id"], "Zm9v")
 
 
+def test_if_we_provide_id_field_it_includes_additional_fields():
+    doc = build_document({"dimensions": {},
+                          "metrics": {"some_metric": 123},
+                          "start_date": date(2014, 2, 19)},
+                         "data_type",
+                         idMapping="idVar",
+                         additionalFields={"idVar": "foo"})
+
+    eq_(doc["_id"], "Zm9v")
+
+
 def test_plugin():
 
     input_document = {


### PR DESCRIPTION
Previously additional fields were added to the documents after that had
all been created. We want to use an additional field as part of creating
the _id so it need to be available to the build_document function. This
commit pushes the additionalFields down into this function.
