### PR TITLE
Empty data set before posting trending

### DIFF
--- a/performanceplatform/collector/ga/trending.py
+++ b/performanceplatform/collector/ga/trending.py
@@ -139,4 +139,5 @@ def main(credentials, data_set_config, query, options, start_at, end_at):
 
     data_set = DataSet.from_config(data_set_config)
 
+    data_set.empty_data_set()
     data_set.post(flattened_data)


### PR DESCRIPTION
If it is not removed, when a page path receives no traffic it will still
be included in the output with it's last values.

I did not work on the trending collector so I'm absolutely certain this is correct, but leaving old values in there seems bad.
