### PR TITLE
BUGFIX: Remove length check on ga.send_data

### DIFF
--- a/performanceplatform/collector/ga/core.py
+++ b/performanceplatform/collector/ga/core.py
@@ -61,10 +61,6 @@ def query_ga(client, config, start_date, end_date):
 
 
 def send_data(data_set, documents, chunk_size):
-    if len(documents) == 0:
-        logging.info("No data returned with current configuration")
-        return
-
     data_set.post(documents, chunk_size=chunk_size)
 
 


### PR DESCRIPTION
Now that we're using generators we can't easily test whether there are
any documents without reading into the generator. It also doesn't give
very much value.

It may be useful in the future for the post method on DataSet to return
the number of documents that it sent.
