### PR TITLE
Set default chunk size for GA collector to 100

### DIFF
--- a/performanceplatform/collector/ga/__init__.py
+++ b/performanceplatform/collector/ga/__init__.py
@@ -16,6 +16,6 @@ def main(credentials, data_set_config, query, options, start_at, end_at):
         start_at, end_at)
 
     data_set = DataSet.from_config(data_set_config)
-    chunk_size = options.get('chunk-size', 0)
+    chunk_size = options.get('chunk-size', 100)
 
     send_data(data_set, documents, chunk_size)


### PR DESCRIPTION
We would like requests chunked up when talking to backdrop as not doing
so has been shown to bring it down. This sets the default to 100 records
so that we don't have to remember to set it explicitly in every config.
