### PR TITLE
Add chunk size to table collector

### DIFF
--- a/performanceplatform/collector/ga/contrib/content/table.py
+++ b/performanceplatform/collector/ga/contrib/content/table.py
@@ -51,4 +51,5 @@ def main(credentials, data_set_config, query, options, start_at, end_at):
 
         documents.extend(ds)
 
-    send_data(DataSet.from_config(data_set_config), documents)
+    chunk_size = options.get('chunk-size', 100)
+    send_data(DataSet.from_config(data_set_config), documents, chunk_size)


### PR DESCRIPTION
chunk_size is a required argument to send_data, so set it in the same
way we are for the ga collector
