### PR TITLE
Compare based on value and not identity

### DIFF
--- a/performanceplatform/utils/data_parser.py
+++ b/performanceplatform/utils/data_parser.py
@@ -100,7 +100,7 @@ def build_document_set(results, data_type, mappings, special_fields,
                        idMapping=None,
                        timespan='week',
                        additionalFields={}):
-    if len(results) is not len(special_fields):
+    if len(results) != len(special_fields):
         raise ValueError(
             "There must be same number of special fields as results")
     return (build_document(item, data_type, special_fields[i], mappings,

--- a/tests/performanceplatform/utils/test_data_parser.py
+++ b/tests/performanceplatform/utils/test_data_parser.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 from datetime import date
-from hamcrest import assert_that, is_, has_entries, has_item, equal_to
+from hamcrest import assert_that, is_, has_entries, has_item, equal_to, is_not, calling, raises
 
 import mock
 
@@ -447,3 +447,10 @@ def test_data_type_can_be_overriden():
     ))
 
     eq_(result[0]['dataType'], 'overriden')
+
+
+def test_build_document_set_handles_big_numbers():
+    results = [0] * 3142
+    special_fields = [0] * 3142
+
+    assert_that(calling(build_document_set).with_args(results, '', {}, special_fields), is_not(raises(ValueError)))


### PR DESCRIPTION
Using `is` in python will compare the two variables for identity i.e. if
they are the same reference to a thing. When you have small numbers
python has a optimization where it will use the same underlying object
and `is` will work. When you are using larger numbers they will no
longer be represented by the same underlying object so using `is` will
return false even if the objects represent the same underlying number.

For this reason it is always sensible to use `==` style comparison for
numbers.
