### PR TITLE
Bump client version to get dry-run data logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ dshelpers>=1.0.4
 unicodecsv
 requests>=1.2.0
 statsd==3.0
-performanceplatform-client==0.2.2
+performanceplatform-client==0.2.6


### PR DESCRIPTION
Previously `--dry-run` would only log the requests url and headers. The
most interesting bit as far is the collector is concerned.

Relies on https://github.com/alphagov/performanceplatform-client/pull/38 being merged.
