### PR TITLE
Fix collection of overlapping day data

### DIFF
--- a/performanceplatform/collector/webtrends/reports.py
+++ b/performanceplatform/collector/webtrends/reports.py
@@ -23,18 +23,15 @@ class Collector(BaseCollector):
             end_date = cls.parse_standard_date_string_to_date(
                 end_at)
             numdays = (end_date - start_date).days + 1
-            end_dates = [(end_date + timedelta(1)) - timedelta(days=x)
-                         for x in reversed(range(0, numdays))]
             start_dates = [end_date - timedelta(days=x)
                            for x in reversed(range(0, numdays))]
             date_range = []
             for i, date in enumerate(start_dates):
-                date_range.append((
-                    cls.parse_date_for_query(date),
-                    cls.parse_date_for_query(end_dates[i])))
+                query_date = cls.parse_date_for_query(date)
+                date_range.append((query_date, query_date))
             return date_range
         else:
-            return [("current_day-2", "current_day-1")]
+            return [("current_day-1", "current_day-1")]
 
     def _make_request(self, start_at_for_webtrends, end_at_for_webtrends):
         return requests_with_backoff.get(

--- a/tests/fixtures/webtrends_day_one.json
+++ b/tests/fixtures/webtrends_day_one.json
@@ -50,7 +50,7 @@
     "accountID": 1
   }, 
   "data": {
-    "10/14/2014-10/15/2014": {
+    "10/14/2014-10/14/2014": {
       "SubRows": {
         "Mozilla": {
           "Attributes": null,

--- a/tests/performanceplatform/collector/webtrends/test_reports.py
+++ b/tests/performanceplatform/collector/webtrends/test_reports.py
@@ -93,7 +93,7 @@ class TestCollector(unittest.TestCase):
                 auth=('abc', 'def'),
                 params={
                     'start_period': "2014m08d03",
-                    'end_period': "2014m08d04",
+                    'end_period': "2014m08d03",
                     'format': 'json'
                 }
             ),
@@ -102,7 +102,7 @@ class TestCollector(unittest.TestCase):
                 auth=('abc', 'def'),
                 params={
                     'start_period': "2014m08d04",
-                    'end_period': "2014m08d05",
+                    'end_period': "2014m08d04",
                     'format': 'json'}
             ),
             call(
@@ -110,7 +110,7 @@ class TestCollector(unittest.TestCase):
                 auth=('abc', 'def'),
                 params={
                     'start_period': "2014m08d05",
-                    'end_period': "2014m08d06",
+                    'end_period': "2014m08d05",
                     'format': 'json'
                 })
         ]
@@ -132,7 +132,7 @@ class TestCollector(unittest.TestCase):
             url="http://this.com/whoop",
             auth=('abc', 'def'),
             params={
-                'start_period': "current_day-2",
+                'start_period': "current_day-1",
                 'end_period': "current_day-1",
                 'format': 'json'
             }
@@ -167,9 +167,9 @@ class TestCollector(unittest.TestCase):
             "2014-08-03",
             "2014-08-05"),
             equal_to([
-                ("2014m08d03", "2014m08d04"),
-                ("2014m08d04", "2014m08d05"),
-                ("2014m08d05", "2014m08d06")
+                ("2014m08d03", "2014m08d03"),
+                ("2014m08d04", "2014m08d04"),
+                ("2014m08d05", "2014m08d05")
             ])
         )
 
@@ -177,7 +177,7 @@ class TestCollector(unittest.TestCase):
         assert_that(
             Collector.date_range_for_webtrends(),
             equal_to([
-                ("current_day-2", "current_day-1")
+                ("current_day-1", "current_day-1")
             ])
         )
 


### PR DESCRIPTION
This will now collect date to date rather than date to date + 1 day.
Initial testing made me think these were the same thing. This was wrong.

Unrelated to this I see that urmy is counting null days as 0 visits and I'm worrying if null is the way webtrends represents 0 visits. If so I may need to make further changes in a separate pull request

Also wondering how spotlight deals with gaps in data? Should the webtrends collector be filling in null days with explicit nulls?
