### PR TITLE
Bump pep8 and ignore E402 error

### DIFF
--- a/pep-it.sh
+++ b/pep-it.sh
@@ -3,5 +3,5 @@
 set -e
 
 basedir=$(dirname $0)
-pep8 --ignore=E201,E202,E241,E251 --exclude=tests,config,build,src,venv,*.egg "$basedir"
-pep8 --ignore=E201,E202,E241,E251,E501 "$basedir/tests"
+pep8 --ignore=E201,E202,E241,E251,E402 --exclude=tests,config,build,src,venv,*.egg "$basedir"
+pep8 --ignore=E201,E202,E241,E251,E402,E501 "$basedir/tests"

--- a/requirements_for_tests.txt
+++ b/requirements_for_tests.txt
@@ -1,6 +1,6 @@
 PyHamcrest
 nose
 mock
-pep8
+pep8==1.6.1
 coverage
 freezegun


### PR DESCRIPTION
Bump pep8 and 'fix' version.

Ignore E402 when running tests - see https://github.com/jcrocholl/pep8/issues/264

