### PR TITLE
Run cronjobs on multiple machines

### DIFF
--- a/pep-it.sh
+++ b/pep-it.sh
@@ -3,5 +3,5 @@
 set -e
 
 basedir=$(dirname $0)
-pep8 --ignore=E201,E202,E241,E251,E402 --exclude=tests,config,build,src,venv,*.egg "$basedir"
+pep8 --ignore=E201,E202,E241,E251,E402 --exclude=tests,config,build,src,venv,*.egg,.ropeproject "$basedir"
 pep8 --ignore=E201,E202,E241,E251,E402,E501 "$basedir/tests"


### PR DESCRIPTION
This should ensure there is a unique list of cronjobs on both machines.

backend-app-1 should only run oddly numbered jobs, backend-app-2 evenly
numbered jobs.

This change also requires a change in pp-deployment to deploy the
collectors to both machines.