### PR TITLE
Clarify crontab generation behaviour

### DIFF
--- a/tests/performanceplatform/collector/test_crontab.py
+++ b/tests/performanceplatform/collector/test_crontab.py
@@ -186,7 +186,7 @@ class TestGenerateCrontab(object):
                 "unique-id-of-my-app"
             )
 
-            assert_that(generated_jobs, has_length(3))
+            assert_that(removeCommentsFromCrontab(generated_jobs), has_length(1))
 
     @patch('socket.gethostname')
     def test_jobs_based_on_hostname_with_2(self, hostname):
@@ -205,7 +205,7 @@ class TestGenerateCrontab(object):
                 "unique-id-of-my-app"
             )
 
-            assert_that(generated_jobs, has_length(3))
+            assert_that(removeCommentsFromCrontab(generated_jobs), has_length(1))
 
     @patch('socket.gethostname')
     def test_jobs_based_on_hostname_with_3(self, hostname):
@@ -224,10 +224,14 @@ class TestGenerateCrontab(object):
                 "unique-id-of-my-app"
             )
 
-            assert_that(generated_jobs, has_length(3))
+            assert_that(removeCommentsFromCrontab(generated_jobs), has_length(1))
 
     def tearDown(self):
         self.patcher.stop()
+
+
+def removeCommentsFromCrontab(generated_jobs):
+    return filter(lambda job: not job.startswith("#"), generated_jobs)
 
 
 class ProcessFailureError(StandardError):

--- a/tests/performanceplatform/collector/test_crontab.py
+++ b/tests/performanceplatform/collector/test_crontab.py
@@ -10,6 +10,7 @@ from mock import patch
 
 
 class TestRemoveExistingCrontab(object):
+
     def setUp(self):
         self.patcher = patch('socket.gethostname')
         self.mock_gethostname = self.patcher.start()
@@ -186,7 +187,8 @@ class TestGenerateCrontab(object):
                 "unique-id-of-my-app"
             )
 
-            assert_that(removeCommentsFromCrontab(generated_jobs), has_length(1))
+            assert_that(
+                removeCommentsFromCrontab(generated_jobs), has_length(1))
 
     @patch('socket.gethostname')
     def test_jobs_based_on_hostname_with_2(self, hostname):
@@ -205,7 +207,8 @@ class TestGenerateCrontab(object):
                 "unique-id-of-my-app"
             )
 
-            assert_that(removeCommentsFromCrontab(generated_jobs), has_length(1))
+            assert_that(
+                removeCommentsFromCrontab(generated_jobs), has_length(1))
 
     @patch('socket.gethostname')
     def test_jobs_based_on_hostname_with_3(self, hostname):
@@ -224,7 +227,8 @@ class TestGenerateCrontab(object):
                 "unique-id-of-my-app"
             )
 
-            assert_that(removeCommentsFromCrontab(generated_jobs), has_length(1))
+            assert_that(
+                removeCommentsFromCrontab(generated_jobs), has_length(1))
 
     def tearDown(self):
         self.patcher.stop()
@@ -235,6 +239,7 @@ def removeCommentsFromCrontab(generated_jobs):
 
 
 class ProcessFailureError(StandardError):
+
     def __init__(self, code, command, output):
         self.code = code
         self.command = command

--- a/tests/performanceplatform/collector/test_crontab.py
+++ b/tests/performanceplatform/collector/test_crontab.py
@@ -189,6 +189,8 @@ class TestGenerateCrontab(object):
 
             assert_that(
                 removeCommentsFromCrontab(generated_jobs), has_length(1))
+            assert_that(removeCommentsFromCrontab(
+                generated_jobs)[0], contains_string("schedule "))
 
     @patch('socket.gethostname')
     def test_jobs_based_on_hostname_with_2(self, hostname):
@@ -209,6 +211,8 @@ class TestGenerateCrontab(object):
 
             assert_that(
                 removeCommentsFromCrontab(generated_jobs), has_length(1))
+            assert_that(removeCommentsFromCrontab(
+                generated_jobs)[0], contains_string("schedule3 "))
 
     @patch('socket.gethostname')
     def test_jobs_based_on_hostname_with_3(self, hostname):
@@ -229,6 +233,8 @@ class TestGenerateCrontab(object):
 
             assert_that(
                 removeCommentsFromCrontab(generated_jobs), has_length(1))
+            assert_that(removeCommentsFromCrontab(
+                generated_jobs)[0], contains_string("schedule2 "))
 
     def tearDown(self):
         self.patcher.stop()


### PR DESCRIPTION
Not immediately obvious when reading that 3 candidate jobs leads to 3
line output, which includes a comment header, a single job and a comment
footer.

Added code to make that explicit.