### PR TITLE
Add more information around HTTP issues

### DIFF
--- a/performanceplatform/utils/http_with_backoff.py
+++ b/performanceplatform/utils/http_with_backoff.py
@@ -21,18 +21,41 @@ class HttpWithBackoff(Http):
         delay = 10
 
         for n in range(_MAX_RETRIES):
-            response = super(HttpWithBackoff, self).request(
+            response, content = super(HttpWithBackoff, self).request(
                 uri,
                 method,
                 body,
                 headers,
                 redirections,
                 connection_type)
-            response_headers = response[0]
-            code = response_headers.status
+            code = response.status
+
+            # This is a shotgun approach to handle the error:
+            #
+            # - 503 Server Unavailable is sensible to use exponential backoff
+            #   and retry.
+            # - 502 Bad Gateway could be due to a backend system timing out
+            #   (due to load) so again, we think it reasonable to retry.
+            # - 403 Forbidden is a weird one. Google Analytics returns a 403
+            #   status code but it can mean a bunch of things. See
+            #   https://developers.google.com/analytics/devguides/reporting/core/v3/coreErrors
+            #   So (for GA at least) we need to check one or more of:
+            #   * the reason
+            #   * the response body, test that it's JSON and parse it
+            #
+            # We probably want to make this backoff strategy pluggable, so
+            # that we can handle:
+            # * Google says not to retry on 503s, but we want to do that for
+            #   backdrop
+            # * how Piwik works
+            # * how Pingdom works
             if code in [403, 502, 503]:
-                retry_info = ('{} request for {} failed with code {} '
-                              '(Attempt {} of {}).'.format(method, uri, code,
+                retry_info = (
+                    '{} request for {} failed with code {},'
+                    'reason {} (Attempt {} of {}).'.format(method,
+                                                           uri,
+                                                           code,
+                                                           response.reason,
                                                            n + 1,
                                                            _MAX_RETRIES))
                 if n + 1 < _MAX_RETRIES:
@@ -43,7 +66,7 @@ class HttpWithBackoff(Http):
             else:
                 # bad status codes should be handled by the Google API
                 # client in the normal way
-                return response
+                return response, content
 
         # we made _MAX_RETRIES requests but none worked
         logging.error(
@@ -52,8 +75,8 @@ class HttpWithBackoff(Http):
             # for logging other request failures
             extra={
                 'exception_class': 'HttpLibException',
-                'exception_message': '{}: {}'.format(response[0].status,
-                                                     response[0].reason)
+                'exception_message': '{}: {}'.format(response.status,
+                                                     response.reason)
             }
         )
-        return response
+        return response, content


### PR DESCRIPTION
The current exponential back-off is a coarse-grained approach to handle
the error. It was introduced in
https://www.pivotaltracker.com/story/show/70748592 and we have:

- 503 Server Unavailable is sensible to use exponential back-off
  and retry
- 502 Bad Gateway could be due to a backend system timing out
  (due to load) so again, we think it reasonable to retry
– 403 Forbidden is a weird one. Google Analytics returns a 403
  status code but it can mean a bunch of things. See
  https://developers.google.com/analytics/devguides/reporting/core/v3/coreErrors
  So (for GA at least) we need to check one or more of:
    * the reason
    * the response body, test that it's JSON and parse it
   
We probably want to make this back-off strategy pluggable, so that we can
handle how:
* Google says not to retry on 503s, but we want to do that for backdrop
* Piwik works
* Pingdom works
* etc