### PR TITLE
Add support for Goals.get API method

### DIFF
--- a/performanceplatform/collector/piwik/core.py
+++ b/performanceplatform/collector/piwik/core.py
@@ -52,6 +52,8 @@ class Parser():
         base_items = []
         special_fields = []
         for date_key, data_points in data.items():
+            if type(data_points) == dict:
+                data_points = [data_points]
             data = self._parse_item(date_key, data_points)
             base_items += data[0]
             special_fields += data[1]

--- a/tests/fixtures/piwik_goal_completion_weekly.json
+++ b/tests/fixtures/piwik_goal_completion_weekly.json
@@ -1,0 +1,14 @@
+{
+  "From 2015-05-11 to 2015-05-17": {
+    "nb_conversions":735,
+    "nb_visits_converted":735,
+    "conversion_rate":18.6,
+    "revenue":0
+  },
+  "From 2015-05-18 to 2015-05-24": {
+    "nb_conversions":730,
+    "nb_visits_converted":730,
+    "conversion_rate":17.03,
+    "revenue":0
+  }
+}


### PR DESCRIPTION
Extend Piwik collector to support the Goals.get API method (and other methods where returned data points are not contained within a list). See https://www.pivotaltracker.com/story/show/95618296 for more information.

