### PR TITLE
Switch back to using 2 hosts for collectors

### DIFF
--- a/performanceplatform/collector/crontab.py
+++ b/performanceplatform/collector/crontab.py
@@ -5,7 +5,7 @@ import sys
 import socket
 
 # Number of hosts we are running the crons on
-NUMBER_OF_HOSTS = 3
+NUMBER_OF_HOSTS = 2
 
 
 ignore_line_re = re.compile("^#.*|\s*$")

--- a/tests/performanceplatform/collector/test_crontab.py
+++ b/tests/performanceplatform/collector/test_crontab.py
@@ -190,7 +190,7 @@ class TestGenerateCrontab(object):
             assert_that(
                 removeCommentsFromCrontab(generated_jobs), has_length(1))
             assert_that(removeCommentsFromCrontab(
-                generated_jobs)[0], contains_string("schedule "))
+                generated_jobs)[0], contains_string("schedule2 "))
 
     @patch('socket.gethostname')
     def test_jobs_based_on_hostname_with_2(self, hostname):
@@ -210,31 +210,11 @@ class TestGenerateCrontab(object):
             )
 
             assert_that(
-                removeCommentsFromCrontab(generated_jobs), has_length(1))
+                removeCommentsFromCrontab(generated_jobs), has_length(2))
             assert_that(removeCommentsFromCrontab(
-                generated_jobs)[0], contains_string("schedule3 "))
-
-    @patch('socket.gethostname')
-    def test_jobs_based_on_hostname_with_3(self, hostname):
-        hostname.return_value = 'development-3'
-
-        temp_contents = ("schedule,query,creds,token,performanceplatforn\n"
-                         "schedule2,query2,creds2,token2,performanceplatforn\n"
-                         "schedule3,query2,creds3,token3,performanceplatforn\n"
-                         )
-
-        with temp_file(temp_contents) as something:
-            generated_jobs = crontab.generate_crontab(
-                [],
-                something,
-                "/path/to/my-app",
-                "unique-id-of-my-app"
-            )
-
-            assert_that(
-                removeCommentsFromCrontab(generated_jobs), has_length(1))
+                generated_jobs)[0], contains_string("schedule"))
             assert_that(removeCommentsFromCrontab(
-                generated_jobs)[0], contains_string("schedule2 "))
+                generated_jobs)[1], contains_string("schedule3 "))
 
     def tearDown(self):
         self.patcher.stop()


### PR DESCRIPTION
When we migrate to gov.uk production, we will be running on 2 hosts
again, so we only need to split the jobs across 2 hosts.