### PR TITLE
Rename log files

### DIFF
--- a/performanceplatform/collector/logging_setup.py
+++ b/performanceplatform/collector/logging_setup.py
@@ -37,9 +37,9 @@ def set_up_logging(app_name, log_level, logfile_path, json_fields=None):
     logger = logging.getLogger()
     logger.setLevel(log_level)
     logger.addHandler(get_log_file_handler(
-        os.path.join(logfile_path, 'collector.log')))
+        os.path.join(logfile_path, 'production.log')))
     logger.addHandler(get_json_log_handler(
-        os.path.join(logfile_path, 'collector.log.json'),
+        os.path.join(logfile_path, 'production.json.log'),
         app_name,
         json_fields=json_fields if json_fields else {}))
     logger.info("{0} logging started".format(app_name))

--- a/tests/performanceplatform/collector/test_logging_setup.py
+++ b/tests/performanceplatform/collector/test_logging_setup.py
@@ -18,7 +18,7 @@ class TestJsonLogging(unittest.TestCase):
         set_up_logging('collector_foo', logging.DEBUG, './log')
         logging.info('Writing out JSON formatted logs m8')
 
-        with open('log/collector.log.json') as log_file:
+        with open('log/production.json.log') as log_file:
             data = json.loads(log_file.readlines()[-1])
 
         assert_that(data, has_entries({
@@ -30,8 +30,8 @@ class TestJsonLogging(unittest.TestCase):
         }))
 
         # Only remove file if assertion passes
-        os.remove('log/collector.log.json')
-        os.remove('log/collector.log')
+        os.remove('log/production.json.log')
+        os.remove('log/production.log')
 
     def test_extra_fields_from_exception(self):
         try:


### PR DESCRIPTION
Now we are on gov.uk infrastructure, there is a convention that
applications log to files production.json.log, and files that have the
extension .log. Although there is nothing in puppet to rotate these log
files, currently, we should rename them to be consistent with other apps
before adding to puppet.