### PR TITLE
Specify a version for mock

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ unicodecsv
 requests>=1.2.0
 statsd==3.0
 performanceplatform-client==0.2.6
+mock==1.0.1


### PR DESCRIPTION
Mock is pulled in by dshelpers -
https://github.com/scraperwiki/data-services-helpers/blob/master/requirements.txt

This is pulling in the latest version, 1.3.0, which is not compatible
with the version of setuptools used on gov.uk infrastructure -
attempting to deploy gives the message

"mock requires setuptools>=17.1. Aborting installation"

As we dont require any later features in mock (yet...) it seems easier
to specify a version to install rather than changing which version of
setuptools is installed on the gov.uk infrastructure.