### PR TITLE
Generate crontab from api

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ Usage
 
 pp-collector takes paths to various JSON files as arguments::
 
-  pp-collector -l [collector slug] -b [backdrop file] -c [credentials file] -t [token file]
+  pp-collector (-l [collector slug] | -q [query file]) -b [backdrop file] -c [credentials file] -t [token file]
 
 All the target files are likely to be located in the performanceplatform-collector-config
 repo. Make sure you update the content of the token file to match the token expected
@@ -75,9 +75,14 @@ Configuration
 
 There are four configuration files that get injected into pp-collector, each file is a required parameter.
 
-Collector configuration
+Collector Slug
+~~~~~~~~~~~~~~
+The collector slug is used to query Stagecraft to get the collector configuration.  The collector configuration returned from Stagecraft is the same as that provided in the query file.
+
+
+Query File
 ~~~~~~~~~~~~~~~~~~~~~~~
-The collector configuration contains everything about what the collector will do during execution. It provides an entrypoint that pp-collector will execute and provide the query and options k-v pairs::
+The query file contains everything about what the collector will do during execution. It provides an entrypoint that pp-collector will execute and provide the query and options k-v pairs. It is being replaced by the collector slug as a parameter::
 
   # pingdom example
   {

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ Usage
 
 pp-collector takes paths to various JSON files as arguments::
 
-  pp-collector -q [query file] -b [backdrop file] -c [credentials file] -t [token file]
+  pp-collector -l [collector slug] -b [backdrop file] -c [credentials file] -t [token file]
 
 All the target files are likely to be located in the performanceplatform-collector-config
 repo. Make sure you update the content of the token file to match the token expected
@@ -75,9 +75,9 @@ Configuration
 
 There are four configuration files that get injected into pp-collector, each file is a required parameter.
 
-Query File
-~~~~~~~~~~
-The query file contains everything about what the collector will do during execution. It provides an entrypoint that pp-collector will execute and provide the query and options k-v pairs::
+Collector configuration
+~~~~~~~~~~~~~~~~~~~~~~~
+The collector configuration contains everything about what the collector will do during execution. It provides an entrypoint that pp-collector will execute and provide the query and options k-v pairs::
 
   # pingdom example
   {
@@ -185,8 +185,8 @@ To retrieve accurate paths for secrets (Google Analytics pathway):
 Piwik
 =====
 
-Example Piwik query file
-------------------------
+Example Piwik configuration
+---------------------------
 
 Here is an example Piwik query file::
 
@@ -214,7 +214,7 @@ Here is an example Piwik query file::
     "token": "piwik_fco"
  }
 
-The above query file will instruct the Piwik collector to fetch data
+The above configuration will instruct the Piwik collector to fetch data
 via the Goals.get method of your Piwik Reporting API endpoint. The
 endpoint is specified via the 'url' setting in your credentials file.
 

--- a/performanceplatform/collector/arguments.py
+++ b/performanceplatform/collector/arguments.py
@@ -21,12 +21,10 @@ def parse_args(name="", args=None):
                         help='JSON file containing credentials '
                              'for the collector',
                         required=True)
-    parser.add_argument('-q', '--query', dest='query',
-                        type=_load_json_file,
-                        help='JSON file containing details '
-                             'about the query to make'
-                             'against the source API '
-                             'and the target data-set',
+    parser.add_argument('-l', '--collector', dest='collector_slug',
+                        type=str,
+                        help='Collector slug to query the API for the '
+                             'collector config',
                         required=True)
     parser.add_argument('-t', '--token', dest='token',
                         type=_load_json_file,

--- a/performanceplatform/collector/arguments.py
+++ b/performanceplatform/collector/arguments.py
@@ -21,11 +21,17 @@ def parse_args(name="", args=None):
                         help='JSON file containing credentials '
                              'for the collector',
                         required=True)
-    parser.add_argument('-l', '--collector', dest='collector_slug',
-                        type=str,
-                        help='Collector slug to query the API for the '
-                             'collector config',
-                        required=True)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('-l', '--collector', dest='collector_slug',
+                       type=str,
+                       help='Collector slug to query the API for the '
+                            'collector config')
+    group.add_argument('-q', '--query', dest='query',
+                       type=_load_json_file,
+                       help='JSON file containing details '
+                            'about the query to make '
+                            'against the source API '
+                            'and the target data-set')
     parser.add_argument('-t', '--token', dest='token',
                         type=_load_json_file,
                         help='JSON file containing token '

--- a/performanceplatform/collector/crontab.py
+++ b/performanceplatform/collector/crontab.py
@@ -88,7 +88,7 @@ def generate_crontab(current_crontab, path_to_jobs, path_to_app, unique_id):
     job_template = '{schedule} ' \
                    '{set_disable_envar}' \
                    '{app_path}/venv/bin/pp-collector ' \
-                   '-q {app_path}/config/{query} ' \
+                   '-l {collector_slug} ' \
                    '-c {app_path}/config/{credentials} ' \
                    '-t {app_path}/config/{token} ' \
                    '-b {app_path}/config/{performanceplatform} ' \
@@ -109,14 +109,14 @@ def generate_crontab(current_crontab, path_to_jobs, path_to_app, unique_id):
                     if skip_job(job_number):
                         continue
 
-                    schedule, query, credentials, \
+                    schedule, collector_slug, credentials, \
                         token, performanceplatform = parsed
 
                     cronjob = job_template.format(
                         schedule=schedule,
                         set_disable_envar=set_disable_envar,
                         app_path=path_to_app,
-                        query=query,
+                        collector_slug=collector_slug,
                         credentials=credentials,
                         token=token,
                         performanceplatform=performanceplatform

--- a/performanceplatform/collector/main.py
+++ b/performanceplatform/collector/main.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 
 from performanceplatform.collector import arguments
 from performanceplatform.collector.logging_setup import set_up_logging
+from performanceplatform.utils.collector import get_config
 
 
 def logging_for_entrypoint(entrypoint, json_fields):
@@ -99,6 +100,8 @@ def _log_collector_instead_of_running(entrypoint, args):
 
 def main():
     args = arguments.parse_args('Performance Platform Collector')
+    config = get_config(args.collector_slug)
+    args.query = config
     entrypoint = args.query['entrypoint']
 
     if args.console_logging:

--- a/performanceplatform/collector/main.py
+++ b/performanceplatform/collector/main.py
@@ -20,7 +20,7 @@ def merge_performanceplatform_config(
         performanceplatform, data_set, token, dry_run=False):
     return {
         'url': '{0}/{1}/{2}'.format(
-            performanceplatform['url'],
+            performanceplatform['backdrop_url'],
             data_set['data-group'],
             data_set['data-type']
         ),
@@ -36,13 +36,15 @@ def make_extra_json_fields(args):
     From the parsed command-line arguments, generate a dictionary of additional
     fields to be inserted into JSON logs (logstash_formatter module)
     """
-    return {
+    extra_json_fields = {
         'data_group': _get_data_group(args.query),
         'data_type': _get_data_type(args.query),
         'data_group_data_type': _get_data_group_data_type(args.query),
         'query': _get_query_params(args.query),
-        'path_to_query': _get_path_to_json_file(args.query),
     }
+    if "path_to_json_file" in args.query:
+        extra_json_fields['path_to_query'] = _get_path_to_json_file(args.query)
+    return extra_json_fields
 
 
 def _get_data_group(query):
@@ -100,8 +102,8 @@ def _log_collector_instead_of_running(entrypoint, args):
 
 def main():
     args = arguments.parse_args('Performance Platform Collector')
-    if args.collector_slug:
-        args.query = get_config(args.collector_slug)
+    if 'collector_slug' in args and args.collector_slug:
+        args.query = get_config(args.collector_slug, args.performanceplatform)
 
     entrypoint = args.query['entrypoint']
 

--- a/performanceplatform/collector/main.py
+++ b/performanceplatform/collector/main.py
@@ -100,8 +100,9 @@ def _log_collector_instead_of_running(entrypoint, args):
 
 def main():
     args = arguments.parse_args('Performance Platform Collector')
-    config = get_config(args.collector_slug)
-    args.query = config
+    if args.collector_slug:
+        args.query = get_config(args.collector_slug)
+
     entrypoint = args.query['entrypoint']
 
     if args.console_logging:

--- a/performanceplatform/utils/collector.py
+++ b/performanceplatform/utils/collector.py
@@ -8,15 +8,14 @@ def get_config(collector_name):
 
     collector_client = CollectorAPI(stagecraft_host, token)
     collector = collector_client.get_collector(collector_name)
-    collector_type = collector_client.get_collector_type(
-        collector.get('type').get('slug'))
     return {
         'query': collector.get('query'),
         'options': collector.get('options'),
         'data-set': {
             'data-group': collector.get('data_set').get('data_group'),
-            'data-type': collector.get('data_set').get('data_type')
+            'data-type': collector.get('data_set').get('data_type'),
+            'bearer_token': collector.get('data_set').get('bearer_token')
         },
-        'entrypoint': collector_type.get('entry_point'),
-        'token': collector_type.get('provider').get('slug')
+        'entrypoint': collector.get('entry_point'),
+        'token': collector.get('provider').get('slug')
     }

--- a/performanceplatform/utils/collector.py
+++ b/performanceplatform/utils/collector.py
@@ -1,13 +1,12 @@
 from performanceplatform.client.collector import CollectorAPI
 
 
-def get_config(collector_name):
-    stagecraft_host = \
-        'http://stagecraft.development.performance.service.gov.uk'
-    token = 'development-oauth-access-token'
-
-    collector_client = CollectorAPI(stagecraft_host, token)
-    collector = collector_client.get_collector(collector_name)
+def get_config(collector_slug, performanceplatform):
+    collector_client = CollectorAPI(
+        performanceplatform['stagecraft_url'],
+        performanceplatform['omniscient_api_token']
+    )
+    collector = collector_client.get_collector(collector_slug)
     return {
         'query': collector.get('query'),
         'options': collector.get('options'),

--- a/performanceplatform/utils/collector.py
+++ b/performanceplatform/utils/collector.py
@@ -1,0 +1,22 @@
+from performanceplatform.client.collector import CollectorAPI
+
+
+def get_config(collector_name):
+    stagecraft_host = \
+        'http://stagecraft.development.performance.service.gov.uk'
+    token = 'development-oauth-access-token'
+
+    collector_client = CollectorAPI(stagecraft_host, token)
+    collector = collector_client.get_collector(collector_name)
+    collector_type = collector_client.get_collector_type(
+        collector.get('type').get('slug'))
+    return {
+        'query': collector.get('query'),
+        'options': collector.get('options'),
+        'data-set': {
+            'data-group': collector.get('data_set').get('data_group'),
+            'data-type': collector.get('data_set').get('data_type')
+        },
+        'entrypoint': collector_type.get('entry_point'),
+        'token': collector_type.get('provider').get('slug')
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ dshelpers>=1.0.4
 unicodecsv
 requests>=1.2.0
 statsd==3.0
-performanceplatform-client==0.2.6
 mock==1.0.1
+performanceplatform-client==0.11.1

--- a/tests/performanceplatform/collector/test_arguments.py
+++ b/tests/performanceplatform/collector/test_arguments.py
@@ -8,29 +8,32 @@ from performanceplatform.collector.arguments import parse_args
 class TestParseArgs(object):
     def test_happy_path(self):
         with json_file({}) as config_path:
-            parse_args(
-                args=["-c", config_path, "-l", "test-collector-slug",
-                      "-t", config_path, "-b", config_path]
-            )
-
-    def test_get_happy_path_args(self):
-        with json_file({}) as config_path:
             args = parse_args(
                 args=["-c", config_path, "-l", "test-collector-slug",
                       "-t", config_path, "-b", config_path]
             )
+
             assert_that(args.collector_slug, equal_to("test-collector-slug"))
 
-    def test_query_file_is_an_invalid_option(self):
+    def test_both_query_file_and_collector_slug_not_allowed(self):
         with json_file({}) as config_path:
             with json_file({}) as query_path:
                 assert_raises(
                     SystemExit, parse_args, args=["-c", config_path,
+                                                  "-l", "test-collector-slug",
                                                   "-q", query_path,
                                                   "-t", config_path,
                                                   "-b", config_path])
 
-    def test_collector_slug_arg_is_required(self):
+    def test_query_file_is_a_valid_option(self):
+        with json_file({}) as config_path:
+            with json_file({}) as query_path:
+                parse_args(
+                    args=["-c", config_path, "-q", query_path,
+                          "-t", config_path, "-b", config_path]
+                )
+
+    def test_collector_slug_or_query_file_is_required(self):
         with json_file({}) as config_path:
             assert_raises(
                 SystemExit, parse_args, args=["-c", config_path,

--- a/tests/performanceplatform/collector/test_arguments.py
+++ b/tests/performanceplatform/collector/test_arguments.py
@@ -1,4 +1,5 @@
 from nose.tools import *
+from hamcrest import equal_to, assert_that
 from tests.performanceplatform.collector.tools \
     import temp_file, json_file, capture_stderr
 from performanceplatform.collector.arguments import parse_args
@@ -7,13 +8,29 @@ from performanceplatform.collector.arguments import parse_args
 class TestParseArgs(object):
     def test_happy_path(self):
         with json_file({}) as config_path:
-            with json_file({}) as query_path:
-                parse_args(
-                    args=["-c", config_path, "-q", query_path,
-                          "-t", config_path, "-b", config_path]
-                )
+            parse_args(
+                args=["-c", config_path, "-l", "test-collector-slug",
+                      "-t", config_path, "-b", config_path]
+            )
 
-    def test_query_arg_is_required(self):
+    def test_get_happy_path_args(self):
+        with json_file({}) as config_path:
+            args = parse_args(
+                args=["-c", config_path, "-l", "test-collector-slug",
+                      "-t", config_path, "-b", config_path]
+            )
+            assert_that(args.collector_slug, equal_to("test-collector-slug"))
+
+    def test_query_file_is_an_invalid_option(self):
+        with json_file({}) as config_path:
+            with json_file({}) as query_path:
+                assert_raises(
+                    SystemExit, parse_args, args=["-c", config_path,
+                                                  "-q", query_path,
+                                                  "-t", config_path,
+                                                  "-b", config_path])
+
+    def test_collector_slug_arg_is_required(self):
         with json_file({}) as config_path:
             assert_raises(
                 SystemExit, parse_args, args=["-c", config_path,
@@ -23,49 +40,40 @@ class TestParseArgs(object):
     def test_config_path_is_required(self):
         with json_file({}) as query_path:
             assert_raises(
-                SystemExit, parse_args, args=["-q", query_path,
+                SystemExit, parse_args, args=["-l", "test-collector-slug",
                                               "-t", query_path,
                                               "-b", query_path])
 
     def test_start_and_end_fields_are_allowed(self):
         with json_file({}) as config_path:
-            with json_file({}) as query_path:
-                parse_args(
-                    args=[
-                        "-c", config_path, "-q", query_path,
-                        "-t", config_path, "-b", config_path,
-                        "-s", "2013-10-10", "-e", "2013-10-10"])
+            parse_args(
+                args=[
+                    "-c", config_path, "-l", "test-collector-slug",
+                    "-t", config_path, "-b", config_path,
+                    "-s", "2013-10-10", "-e", "2013-10-10"])
 
     def test_start_at_must_be_parsable_as_a_date(self):
         with json_file({}) as config_path:
-            with json_file({}) as query_path:
-                assert_raises(
-                    SystemExit, parse_args, args=[
-                        "-c", config_path, "-q", query_path,
-                        "-t", config_path, "-b", config_path,
-                        "-s", "not-a-date"])
+            assert_raises(
+                SystemExit, parse_args, args=[
+                    "-c", config_path,
+                    "-l", "test-collector-slug",
+                    "-t", config_path, "-b", config_path,
+                    "-s", "not-a-date"])
 
     def test_end_at_must_be_parsable_as_a_date(self):
         with json_file({}) as config_path:
-            with json_file({}) as query_path:
-                assert_raises(
-                    SystemExit, parse_args, args=[
-                        "-c", config_path, "-q", query_path,
-                        "-t", config_path, "-b", config_path,
-                        "-e", "not-a-date"])
-
-    def test_query_file_must_be_json(self):
-        with capture_stderr() as stderr:
-            with temp_file("not json") as query_path:
-                assert_raises(
-                    SystemExit, parse_args, args=["-q", query_path])
-                ok_("invalid _load_json_file value" in stderr.getvalue())
+            assert_raises(
+                SystemExit, parse_args, args=[
+                    "-c", config_path,
+                    "-l", "test-collector-slug",
+                    "-t", config_path, "-b", config_path,
+                    "-e", "not-a-date"])
 
     def test_config_file_must_be_json(self):
         with capture_stderr() as stderr:
             with temp_file("not json") as config_path:
-                with json_file({}) as query_path:
-                    args = ["-c", config_path, "-q", query_path]
-                    assert_raises(
-                        SystemExit, parse_args, args=args)
-                    ok_("invalid _load_json_file value" in stderr.getvalue())
+                args = ["-c", config_path]
+                assert_raises(
+                    SystemExit, parse_args, args=args)
+                ok_("invalid _load_json_file value" in stderr.getvalue())

--- a/tests/performanceplatform/collector/test_crontab.py
+++ b/tests/performanceplatform/collector/test_crontab.py
@@ -77,7 +77,7 @@ class TestGenerateCrontab(object):
             assert_that(generated_jobs, has_item("other cronjob"))
 
     def test_some_cronjobs_are_added_between_containing_comments(self):
-        with temp_file("schedule,query.json,creds.json,token.json,performanceplatform.json") as jobs_path:
+        with temp_file("schedule,collector-slug,creds.json,token.json,performanceplatform.json") as jobs_path:
             generated_jobs = crontab.generate_crontab(
                 [],
                 jobs_path,
@@ -90,7 +90,7 @@ class TestGenerateCrontab(object):
                         has_item(contains_string("schedule")))
             assert_that(generated_jobs,
                         has_item(
-                            contains_string("-q /path/to/my-app/config/query.json")))
+                            contains_string("-l collector-slug")))
             assert_that(generated_jobs,
                         has_item(
                             contains_string("-c /path/to/my-app/config/creds.json")))
@@ -105,7 +105,7 @@ class TestGenerateCrontab(object):
                         has_item('# End performanceplatform.collector jobs for some_id'))
 
     def test_added_jobs_run_the_crontab_module(self):
-        with temp_file("schedule,query.json,creds.json,token.json,performanceplatform.json") as jobs_path:
+        with temp_file("schedule,collector-slug,creds.json,token.json,performanceplatform.json") as jobs_path:
             generated_jobs = crontab.generate_crontab(
                 [],
                 jobs_path,
@@ -116,7 +116,7 @@ class TestGenerateCrontab(object):
                             contains_string("pp-collector")))
 
     def test_existing_pp_cronjobs_are_purged(self):
-        with temp_file("schedule,query.json,creds.json,token.json,performanceplatform.json") as jobs_path:
+        with temp_file("schedule,collector-slug,creds.json,token.json,performanceplatform.json") as jobs_path:
             generated_jobs = crontab.generate_crontab(
                 [
                     '# Begin performanceplatform.collector jobs for some_id',
@@ -156,7 +156,7 @@ class TestGenerateCrontab(object):
     def test_can_handle_whitespace_and_comments(self):
         temp_contents = ("# some comment\n"
                          "          \n"
-                         "schedule,query,creds,token,performanceplatforn\n")
+                         "schedule,collector-slug,creds,token,performanceplatform\n")
 
         with temp_file(temp_contents) as something:
             generated_jobs = crontab.generate_crontab(
@@ -165,7 +165,7 @@ class TestGenerateCrontab(object):
                 "/path/to/my-app",
                 "unique-id-of-my-app"
             )
-            job_contains = "pp-collector -q /path/to/my-app/config/query"
+            job_contains = "pp-collector -l collector-slug"
             assert_that(generated_jobs,
                         has_item(
                             contains_string(job_contains)))
@@ -174,9 +174,9 @@ class TestGenerateCrontab(object):
     def test_jobs_based_on_hostname_with_1(self, hostname):
         hostname.return_value = 'development-1'
 
-        temp_contents = ("schedule,query,creds,token,performanceplatforn\n"
-                         "schedule2,query2,creds2,token2,performanceplatforn\n"
-                         "schedule3,query2,creds3,token3,performanceplatforn\n"
+        temp_contents = ("schedule,collector-slug,creds,token,performanceplatform\n"
+                         "schedule2,collector-slug2,creds2,token2,performanceplatform\n"
+                         "schedule3,collector-slug2,creds3,token3,performanceplatform\n"
                          )
 
         with temp_file(temp_contents) as something:
@@ -196,9 +196,9 @@ class TestGenerateCrontab(object):
     def test_jobs_based_on_hostname_with_2(self, hostname):
         hostname.return_value = 'development-2'
 
-        temp_contents = ("schedule,query,creds,token,performanceplatforn\n"
-                         "schedule2,query2,creds2,token2,performanceplatforn\n"
-                         "schedule3,query2,creds3,token3,performanceplatforn\n"
+        temp_contents = ("schedule,collector-slug,creds,token,performanceplatform\n"
+                         "schedule2,collector-slug2,creds2,token2,performanceplatform\n"
+                         "schedule3,collector-slug2,creds3,token3,performanceplatform\n"
                          )
 
         with temp_file(temp_contents) as something:

--- a/tests/performanceplatform/collector/test_main.py
+++ b/tests/performanceplatform/collector/test_main.py
@@ -51,9 +51,7 @@ class TestMain(unittest.TestCase):
     @mock.patch('performanceplatform.collector.arguments.parse_args')
     @mock.patch(
         'performanceplatform.client.collector.CollectorAPI.get_collector')
-    @mock.patch(
-        'performanceplatform.client.collector.CollectorAPI.get_collector_type')
-    def test_collectors_can_be_disabled(self, mock_get_collector_type,
+    def test_collectors_can_be_disabled(self,
                                         mock_get_collector,
                                         mock_parse_args,
                                         mock_run_collector,
@@ -95,14 +93,11 @@ class TestMain(unittest.TestCase):
     @mock.patch('performanceplatform.collector.main._run_collector')
     @mock.patch(
         'performanceplatform.client.collector.CollectorAPI.get_collector')
-    @mock.patch(
-        'performanceplatform.client.collector.CollectorAPI.get_collector_type')
     @mock.patch('performanceplatform.utils.collector.get_config')
     @mock.patch('performanceplatform.collector.arguments.parse_args')
     def test_get_config_called_if_collector_in_args(self,
                                                     mock_parse_args,
                                                     mock_get_config,
-                                                    mock_get_collector_type,
                                                     mock_get_collector,
                                                     mock_run_collector):
         mock_parse_args.return_value = Namespace(

--- a/tests/performanceplatform/collector/test_main.py
+++ b/tests/performanceplatform/collector/test_main.py
@@ -1,3 +1,4 @@
+from argparse import Namespace
 from hamcrest import assert_that, equal_to
 import mock
 import os
@@ -76,3 +77,38 @@ class TestMain(unittest.TestCase):
                 os.environ['DISABLE_COLLECTORS'] = orig_disable_collectors
             else:
                 os.unsetenv('DISABLE_COLLECTORS')
+
+    @mock.patch('performanceplatform.collector.main._run_collector')
+    @mock.patch('performanceplatform.utils.collector.get_config')
+    @mock.patch('performanceplatform.collector.arguments.parse_args')
+    def test_get_config_not_called_if_query_file_in_args(self,
+                                                         mock_parse_args,
+                                                         mock_get_config,
+                                                         mock_run_collector):
+        mock_parse_args.return_value = Namespace(query={})
+        try:
+            main.main()
+            assert not mock_get_config.called
+        except:
+            pass
+
+    @mock.patch('performanceplatform.collector.main._run_collector')
+    @mock.patch(
+        'performanceplatform.client.collector.CollectorAPI.get_collector')
+    @mock.patch(
+        'performanceplatform.client.collector.CollectorAPI.get_collector_type')
+    @mock.patch('performanceplatform.utils.collector.get_config')
+    @mock.patch('performanceplatform.collector.arguments.parse_args')
+    def test_get_config_called_if_collector_in_args(self,
+                                                    mock_parse_args,
+                                                    mock_get_config,
+                                                    mock_get_collector_type,
+                                                    mock_get_collector,
+                                                    mock_run_collector):
+        mock_parse_args.return_value = Namespace(
+            collector_slug="some-collector")
+        try:
+            main.main()
+            assert mock_get_config.called
+        except:
+            pass

--- a/tests/performanceplatform/collector/test_main.py
+++ b/tests/performanceplatform/collector/test_main.py
@@ -48,7 +48,13 @@ class TestMain(unittest.TestCase):
                 '_log_collector_instead_of_running')
     @mock.patch('performanceplatform.collector.main._run_collector')
     @mock.patch('performanceplatform.collector.arguments.parse_args')
-    def test_collectors_can_be_disabled(self, mock_parse_args,
+    @mock.patch(
+        'performanceplatform.client.collector.CollectorAPI.get_collector')
+    @mock.patch(
+        'performanceplatform.client.collector.CollectorAPI.get_collector_type')
+    def test_collectors_can_be_disabled(self, mock_get_collector_type,
+                                        mock_get_collector,
+                                        mock_parse_args,
                                         mock_run_collector,
                                         mock_log_collector_instead_of_running):
         orig_disable_collectors = os.getenv('DISABLE_COLLECTORS')

--- a/tests/performanceplatform/collector/test_main.py
+++ b/tests/performanceplatform/collector/test_main.py
@@ -11,7 +11,7 @@ class TestMain(unittest.TestCase):
 
     def test_merge_performanceplatform_config(self):
         performanceplatform = {
-            'url': 'http://foo/data',
+            'backdrop_url': 'http://foo/data',
         }
         data_set = {
             'data-group': 'group',
@@ -29,7 +29,7 @@ class TestMain(unittest.TestCase):
 
     def test_merge_performanceplatform_config_with_dry_run(self):
         performanceplatform = {
-            'url': 'http://foo/data',
+            'backdrop_url': 'http://foo/data',
         }
         data_set = {
             'data-group': 'group',
@@ -83,7 +83,12 @@ class TestMain(unittest.TestCase):
                                                          mock_parse_args,
                                                          mock_get_config,
                                                          mock_run_collector):
-        mock_parse_args.return_value = Namespace(query={})
+        mock_parse_args.return_value = Namespace(
+            query={
+                'entrypoint': 'foo.collector'
+            },
+            console_logging=False
+        )
         try:
             main.main()
             assert not mock_get_config.called
@@ -101,7 +106,14 @@ class TestMain(unittest.TestCase):
                                                     mock_get_collector,
                                                     mock_run_collector):
         mock_parse_args.return_value = Namespace(
-            collector_slug="some-collector")
+            collector_slug="some-collector",
+            performanceplatform={
+                'backdrop_url': 'http://foo/data',
+                'stagecraft_url': 'http://foo.config.uk',
+                'omniscient_api_token': 'fake-access-token'
+            },
+            console_logging=False
+        )
         try:
             main.main()
             assert mock_get_config.called

--- a/tests/performanceplatform/utils/test_collector_config.py
+++ b/tests/performanceplatform/utils/test_collector_config.py
@@ -1,0 +1,60 @@
+import argparse
+import unittest
+from hamcrest import assert_that, equal_to
+from mock import patch
+from performanceplatform.collector.arguments import parse_args
+from performanceplatform.utils.collector import get_config
+from tests.performanceplatform.collector.tools import json_file
+
+
+class ConfigTest(unittest.TestCase):
+    @patch('performanceplatform.client.collector.CollectorAPI.get_collector')
+    @patch(
+        'performanceplatform.client.collector.CollectorAPI.get_collector_type')
+    def test_get_config(self, mock_collector_type, mock_collector):
+
+        mock_collector.return_value = {
+            'id': '1234',
+            'name': 'foo',
+            'slug': 'foo',
+            'query': {},
+            'options': {},
+            'type': {
+                'id': '1234',
+                'name': 'foo-type'
+            },
+            'data_source': {
+                'id': '1234',
+                'slug': 'foo-data-source'
+            },
+            'data_set': {
+                'data_type': 'foo-data-type',
+                'data_group': 'foo-data-group'
+            }
+        }
+
+        mock_collector_type.return_value = {
+            'id': '1234',
+            'name': 'foo-type',
+            'entry_point': 'foo.collector',
+            'query_schema': {},
+            'options_schema': {},
+            'provider': {
+                'id': '1234',
+                'slug': 'foo-provider'
+            }
+        }
+
+        config_data = get_config('foo')
+        expected_data = {
+            'query': {},
+            'options': {},
+            'data-set': {
+                'data-group': 'foo-data-group',
+                'data-type': 'foo-data-type'
+            },
+            "entrypoint": 'foo.collector',
+            "token": "foo-provider"
+        }
+
+        assert_that(config_data, equal_to(expected_data))

--- a/tests/performanceplatform/utils/test_collector_config.py
+++ b/tests/performanceplatform/utils/test_collector_config.py
@@ -9,9 +9,7 @@ from tests.performanceplatform.collector.tools import json_file
 
 class ConfigTest(unittest.TestCase):
     @patch('performanceplatform.client.collector.CollectorAPI.get_collector')
-    @patch(
-        'performanceplatform.client.collector.CollectorAPI.get_collector_type')
-    def test_get_config(self, mock_collector_type, mock_collector):
+    def test_get_config(self, mock_collector):
 
         mock_collector.return_value = {
             'id': '1234',
@@ -19,8 +17,10 @@ class ConfigTest(unittest.TestCase):
             'slug': 'foo',
             'query': {},
             'options': {},
+            'entry_point': 'foo.collector',
             'type': {
                 'id': '1234',
+                'slug': 'foo-type',
                 'name': 'foo-type'
             },
             'data_source': {
@@ -29,16 +29,9 @@ class ConfigTest(unittest.TestCase):
             },
             'data_set': {
                 'data_type': 'foo-data-type',
-                'data_group': 'foo-data-group'
-            }
-        }
-
-        mock_collector_type.return_value = {
-            'id': '1234',
-            'name': 'foo-type',
-            'entry_point': 'foo.collector',
-            'query_schema': {},
-            'options_schema': {},
+                'data_group': 'foo-data-group',
+                'bearer_token': 'foo-token'
+            },
             'provider': {
                 'id': '1234',
                 'slug': 'foo-provider'
@@ -51,7 +44,8 @@ class ConfigTest(unittest.TestCase):
             'options': {},
             'data-set': {
                 'data-group': 'foo-data-group',
-                'data-type': 'foo-data-type'
+                'data-type': 'foo-data-type',
+                'bearer_token': 'foo-token'
             },
             "entrypoint": 'foo.collector',
             "token": "foo-provider"

--- a/tests/performanceplatform/utils/test_collector_config.py
+++ b/tests/performanceplatform/utils/test_collector_config.py
@@ -1,10 +1,7 @@
-import argparse
 import unittest
 from hamcrest import assert_that, equal_to
 from mock import patch
-from performanceplatform.collector.arguments import parse_args
 from performanceplatform.utils.collector import get_config
-from tests.performanceplatform.collector.tools import json_file
 
 
 class ConfigTest(unittest.TestCase):
@@ -38,7 +35,13 @@ class ConfigTest(unittest.TestCase):
             }
         }
 
-        config_data = get_config('foo')
+        performanceplatform = {
+            'url': 'http://foo/data',
+            'stagecraft_url': 'http://foo.config.uk',
+            'omniscient_api_token': 'fake-access-token'
+        }
+
+        config_data = get_config('foo', performanceplatform)
         expected_data = {
             'query': {},
             'options': {},

--- a/tools/one-off/recollect.py
+++ b/tools/one-off/recollect.py
@@ -59,7 +59,8 @@ def get_config(config_path, config_id):
 
 
 def get_base_url(config_path):
-    return load_json(join(config_path, 'performanceplatform.json'))['url']
+    return load_json(join(
+        config_path, 'performanceplatform.json'))['backdrop_url']
 
 
 def empty_dataset(config_path, data_set, token):


### PR DESCRIPTION
Run collector with collector slug argument.
The arguments from the crontab entry have been updated to pass a
collector slug to the pp-collector job rather than the location of
the collector configuration (query) file.

Dependent on: #126 and https://github.gds/gds/alphagov-deployment/pull/1031

Pivotal: https://www.pivotaltracker.com/story/show/98935742