### PR TITLE
Fix how mutually exclusive arguments are handled.

### DIFF
--- a/performanceplatform/collector/main.py
+++ b/performanceplatform/collector/main.py
@@ -102,7 +102,7 @@ def _log_collector_instead_of_running(entrypoint, args):
 
 def main():
     args = arguments.parse_args('Performance Platform Collector')
-    if 'collector_slug' in args:
+    if args.collector_slug:
         args.query = get_config(args.collector_slug, args.performanceplatform)
 
     entrypoint = args.query['entrypoint']

--- a/tests/performanceplatform/collector/test_main.py
+++ b/tests/performanceplatform/collector/test_main.py
@@ -56,6 +56,13 @@ class TestMain(unittest.TestCase):
                                         mock_run_collector,
                                         mock_log_collector_instead_of_running):
         orig_disable_collectors = os.getenv('DISABLE_COLLECTORS')
+        mock_parse_args.return_value = Namespace(
+            collector_slug=None,
+            query={
+                'entrypoint': 'foo.collector'
+            },
+            console_logging=True,
+        )
         try:
             os.environ['DISABLE_COLLECTORS'] = 'false'
             main.main()
@@ -86,7 +93,8 @@ class TestMain(unittest.TestCase):
             query={
                 'entrypoint': 'foo.collector'
             },
-            console_logging=False
+            console_logging=False,
+            collector_slug=None
         )
         try:
             main.main()
@@ -111,7 +119,8 @@ class TestMain(unittest.TestCase):
                 'stagecraft_url': 'http://foo.config.uk',
                 'omniscient_api_token': 'fake-access-token'
             },
-            console_logging=False
+            console_logging=False,
+            query=None
         )
         try:
             main.main()


### PR DESCRIPTION
Argparse adds all command line arguments that have been set to mutually exclusive
to the return object. It then gives all of the keys that didn't appear on the
command line a value of None.

This was causing pp-collector to error when the query flag was passed and a
connection to stagecraft was not available. A connection to stagecraft should
only be attempted if the collector-slug flag is used.