### PR TITLE
Add option to purge data set in GA collector

### DIFF
--- a/performanceplatform/utils/data_pusher.py
+++ b/performanceplatform/utils/data_pusher.py
@@ -6,9 +6,12 @@ class Pusher(object):
     def __init__(self, target_data_set_config, options):
         self.data_set_client = DataSet.from_config(target_data_set_config)
         self.chunk_size = options.get('chunk-size', 100)
+        self.empty_data_set = options.get('empty-data-set', False)
 
     def push(self, data):
         if data:
+            if self.empty_data_set:
+                self.data_set_client.empty_data_set()
             self.data_set_client.post(
                 data, chunk_size=self.chunk_size)
         else:


### PR DESCRIPTION
None of the web traffic modules for Activity on GOV.UK that purport
to display information for the last seven days actually do so.

The module config only applies two filters on the data in the dataset
in backdrop: limiting the number of results returned to 10 and sorting
by the number of page views.

The dataset contains all data for the modules since records began.
Therefore if a page had more traffic in a week than any other for
whatever reason it will continue to be number one most viewed because
we aren't filtering by timestamp.

There are a couple of ways to filter by timestamp:
1. Pass in a start date and end date.
It's not possible to pass in dynamic dates to the module config, so
this has been ruled out.

2. Add filter parameters of duration and period to the module config.
This sounds like it could work, but if you add the period clause you
also have to add a group_by clause. Grouping aggregates the data being
returned, so you lose most of the detail e.g. page title and page path,
used by spotlight to link to the pages.

3. Add another sort_by clause.
Adding a clause to sort by timestamp descending and then by page views
fixes the problem. However to implement this we would have to change
the module schema to allow a list of sort_by clauses in the module
config, rather than just a string. Another issue is that currently
spotlight only supports a string in the sort_by field. It would be a
much longer (larger) fix to change spotlight and stagecraft to support
lists.

Another option is to change how the data is collected in the first
place.

The data for these web traffic dashboards is collected from Google
Analytics whose default frequency of collection is weekly. If we
change the GA core collector to act like the GA trending collector
and allow it to purge the existing data when it collects more, the
datasets will only ever contain one weeks' worth of data, the data
from the most recent full week (Mon-Sun) that the collector ran.

This last option is one that we have decided to implement. An entry
will be added to the options in the collector config for the affected
datasets that instructs the GA collector to purge the data in the
dataset.

The affected datasets are:
govuk_most_viewed
govuk_most_viewed_policies
govuk_most_viewed_news

Pivotal: https://www.pivotaltracker.com/story/show/100818900