### PR TITLE
Add option to empty data set when pushing

### DIFF
--- a/performanceplatform/collector/ga/__init__.py
+++ b/performanceplatform/collector/ga/__init__.py
@@ -15,4 +15,7 @@ def main(credentials, data_set_config, query, options, start_at, end_at):
         data_set_config['data-type'],
         start_at, end_at)
 
+    if query.get('empty_data_set'):
+        options['empty_data_set'] = True
+
     Pusher(data_set_config, options).push(documents)

--- a/performanceplatform/utils/data_pusher.py
+++ b/performanceplatform/utils/data_pusher.py
@@ -6,8 +6,11 @@ class Pusher(object):
     def __init__(self, target_data_set_config, options):
         self.data_set_client = DataSet.from_config(target_data_set_config)
         self.chunk_size = options.get('chunk-size', 100)
+        self.options = options
 
     def push(self, data):
+        if self.options.get('empty_data_set'):
+            self.data_set_client.empty_data_set()
         if data:
             self.data_set_client.post(
                 data, chunk_size=self.chunk_size)

--- a/tests/performanceplatform/utils/test_data_pusher.py
+++ b/tests/performanceplatform/utils/test_data_pusher.py
@@ -37,3 +37,13 @@ class TestPusher(unittest.TestCase):
         data_set_config = {'beep': 'boop'}
         Pusher(data_set_config, {}).push([])
         assert_that(mock_data_set_client.post.called, equal_to(False))
+
+    @patch('performanceplatform.utils.data_pusher.DataSet.from_config')
+    def test_empties_dataset_when_empty_option_set(self, mock_from_config):
+        mock_data_set_client = Mock()
+        mock_from_config.return_value = mock_data_set_client
+        data_set_config = {'beep': 'boop'}
+        data = {'some': 'data'}
+        Pusher(data_set_config, {'empty_data_set': True}).push(data)
+        mock_data_set_client.empty_data_set.assert_called_once()
+        mock_data_set_client.post.assert_called_once()


### PR DESCRIPTION
This is being added so we can empty the most visited data set, which we
only show the last 7 days of data for, and dont need historical data for