### PR TITLE
Bump version

### DIFF
--- a/performanceplatform/collector/__init__.py
+++ b/performanceplatform/collector/__init__.py
@@ -2,6 +2,6 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
-__version__ = "0.1.2"
+__version__ = "0.2.0"
 __author__ = "GDS Developers"
 __author_email__ = "performance@digital.cabinet-office.gov.uk"


### PR DESCRIPTION
Bump to 0.2.0. This contains 193fea94f186f5fd9191bdaf0373627b14a846d5
which makes pip installing this package actually work