### PR TITLE
Fix installation on python3

### DIFF
--- a/performanceplatform/collector/__init__.py
+++ b/performanceplatform/collector/__init__.py
@@ -2,6 +2,6 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __author__ = "GDS Developers"
 __author_email__ = "performance@digital.cabinet-office.gov.uk"

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def _get_version():
         data,
         re.M | re.I
     ).group(1).strip()
-    return version.encode('ascii')
+    return version
 
 
 def _get_requirements(fname):


### PR DESCRIPTION
Trying to install the package on python3 gives the error "TypeError:
can't concat bytes to str". Removing the encode('ascii') works on both
python2 and python3 tested by installing from a local checkout using pyenv to
switch versions