### PR TITLE
Bump version

### DIFF
--- a/performanceplatform/collector/__init__.py
+++ b/performanceplatform/collector/__init__.py
@@ -2,6 +2,6 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 __author__ = "GDS Developers"
 __author_email__ = "performance@digital.cabinet-office.gov.uk"


### PR DESCRIPTION
The publish.sh script will push and tag the repo at the commit where the
__init__.py script version was changed - in the last PR, the __init__.py
version was changed in the first commit, so none of the other 3 commits
of the PR were pushed to pypi. So bump the version again.