### PR TITLE
Bump version

### DIFF
--- a/performanceplatform/collector/__init__.py
+++ b/performanceplatform/collector/__init__.py
@@ -2,6 +2,6 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 __author__ = "GDS Developers"
 __author_email__ = "performance@digital.cabinet-office.gov.uk"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pytz==2013d
 argparse
 python-dateutil
 logstash_formatter
-gapy==1.3.1
+gapy==1.3.2
 google-api-python-client==1.0
 lxml>=3.2.0
 dshelpers>=1.0.4


### PR DESCRIPTION
Pull request alphagov/stagecraft#426 is failing to build due to this repo not recognising the latest version of the gapy client so bumping this repo, gapy and stagecraft in an attempt to resolve this.