### PR TITLE
Log to stagecraft

### DIFF
--- a/performanceplatform/collector/__init__.py
+++ b/performanceplatform/collector/__init__.py
@@ -2,6 +2,6 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 __author__ = "GDS Developers"
 __author_email__ = "performance@digital.cabinet-office.gov.uk"

--- a/performanceplatform/collector/logging_setup.py
+++ b/performanceplatform/collector/logging_setup.py
@@ -1,7 +1,6 @@
 from logstash_formatter import LogstashFormatter
 import logging
 import os
-import pdb
 import sys
 import traceback
 
@@ -32,14 +31,22 @@ def uncaught_exception_handler(*exc_info):
     logging.error("Unhandled exception: %s", text, extra=extra)
 
 
-def set_up_logging(app_name, log_level, logfile_path, json_fields=None):
+def set_up_logging(
+        app_name,
+        log_level,
+        logfile_path,
+        logfile_name,
+        json_fields=None):
+
+    if logfile_name is None:
+        logfile_name = 'production'
     sys.excepthook = uncaught_exception_handler
     logger = logging.getLogger()
     logger.setLevel(log_level)
     logger.addHandler(get_log_file_handler(
-        os.path.join(logfile_path, 'production.log')))
+        os.path.join(logfile_path, '{}.log'.format(logfile_name))))
     logger.addHandler(get_json_log_handler(
-        os.path.join(logfile_path, 'production.json.log'),
+        os.path.join(logfile_path, '{}.json.log'.format(logfile_name)),
         app_name,
         json_fields=json_fields if json_fields else {}))
     logger.info("{0} logging started".format(app_name))

--- a/performanceplatform/collector/main.py
+++ b/performanceplatform/collector/main.py
@@ -9,44 +9,6 @@ from performanceplatform.collector.logging_setup import set_up_logging
 from performanceplatform.utils.collector import get_config
 
 
-def logging_for_entrypoint(entrypoint, json_fields):
-    logfile_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), '..', '..', 'log')
-    loglevel = getattr(logging, os.environ.get('LOGLEVEL', 'INFO').upper())
-    set_up_logging(entrypoint, loglevel, logfile_path, json_fields)
-
-
-def merge_performanceplatform_config(
-        performanceplatform, data_set, token, dry_run=False):
-    return {
-        'url': '{0}/{1}/{2}'.format(
-            performanceplatform['backdrop_url'],
-            data_set['data-group'],
-            data_set['data-type']
-        ),
-        'token': token['token'],
-        'data-group': data_set['data-group'],
-        'data-type': data_set['data-type'],
-        'dry_run': dry_run
-    }
-
-
-def make_extra_json_fields(args):
-    """
-    From the parsed command-line arguments, generate a dictionary of additional
-    fields to be inserted into JSON logs (logstash_formatter module)
-    """
-    extra_json_fields = {
-        'data_group': _get_data_group(args.query),
-        'data_type': _get_data_type(args.query),
-        'data_group_data_type': _get_data_group_data_type(args.query),
-        'query': _get_query_params(args.query),
-    }
-    if "path_to_json_file" in args.query:
-        extra_json_fields['path_to_query'] = _get_path_to_json_file(args.query)
-    return extra_json_fields
-
-
 def _get_data_group(query):
     return query['data-set']['data-group']
 
@@ -72,11 +34,68 @@ def _get_path_to_json_file(query):
     return query['path_to_json_file']
 
 
-def _run_collector(entrypoint, args):
+def make_extra_json_fields(args):
+    """
+    From the parsed command-line arguments, generate a dictionary of additional
+    fields to be inserted into JSON logs (logstash_formatter module)
+    """
+    extra_json_fields = {
+        'data_group': _get_data_group(args.query),
+        'data_type': _get_data_type(args.query),
+        'data_group_data_type': _get_data_group_data_type(args.query),
+        'query': _get_query_params(args.query),
+    }
+    if "path_to_json_file" in args.query:
+        extra_json_fields['path_to_query'] = _get_path_to_json_file(args.query)
+    return extra_json_fields
+
+
+def logging_for_entrypoint(
+        entrypoint, json_fields, logfile_path, logfile_name):
+    if logfile_path is None:
+        logfile_path = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)), '..', '..', 'log')
+    loglevel = getattr(logging, os.environ.get('LOGLEVEL', 'INFO').upper())
+    set_up_logging(
+        entrypoint, loglevel, logfile_path, logfile_name, json_fields)
+
+
+def _log_collector_instead_of_running(entrypoint, args):
+    logged_args = {
+        'start_at': args.start_at,
+        'end_at': args.end_at,
+        'query': {k: args.query[k] for k in ('data-set', 'query', 'options')}
+    }
+    logging.info(
+        'Collector {} NOT run with the following {}'.format(entrypoint,
+                                                            logged_args))
+
+
+def merge_performanceplatform_config(
+        performanceplatform, data_set, token, dry_run=False):
+    return {
+        'url': '{0}/{1}/{2}'.format(
+            performanceplatform['backdrop_url'],
+            data_set['data-group'],
+            data_set['data-type']
+        ),
+        'token': token['token'],
+        'data-group': data_set['data-group'],
+        'data-type': data_set['data-type'],
+        'dry_run': dry_run
+    }
+
+
+def _run_collector(entrypoint, args, logfile_path=None, logfile_name=None):
     if args.console_logging:
         logging.basicConfig(level=logging.INFO)
     else:
-        logging_for_entrypoint(entrypoint, make_extra_json_fields(args))
+        logging_for_entrypoint(
+            entrypoint,
+            make_extra_json_fields(args),
+            logfile_path,
+            logfile_name
+        )
 
     if os.environ.get('DISABLE_COLLECTORS', 'false') == 'true':
         _log_collector_instead_of_running(entrypoint, args)
@@ -98,17 +117,6 @@ def _run_collector(entrypoint, args):
             args.start_at,
             args.end_at
         )
-
-
-def _log_collector_instead_of_running(entrypoint, args):
-    logged_args = {
-        'start_at': args.start_at,
-        'end_at': args.end_at,
-        'query': {k: args.query[k] for k in ('data-set', 'query', 'options')}
-    }
-    logging.info(
-        'Collector {} NOT run with the following {}'.format(entrypoint,
-                                                            logged_args))
 
 
 def main():

--- a/tests/performanceplatform/collector/test_logging_setup.py
+++ b/tests/performanceplatform/collector/test_logging_setup.py
@@ -15,7 +15,7 @@ class TestJsonLogging(unittest.TestCase):
 
     def test_json_log_written_when_logger_called(self):
 
-        set_up_logging('collector_foo', logging.DEBUG, './log')
+        set_up_logging('collector_foo', logging.DEBUG, './log', None)
         logging.info('Writing out JSON formatted logs m8')
 
         with open('log/production.json.log') as log_file:

--- a/tests/performanceplatform/collector/test_main.py
+++ b/tests/performanceplatform/collector/test_main.py
@@ -47,13 +47,11 @@ class TestMain(unittest.TestCase):
 
     @mock.patch('performanceplatform.collector.main.'
                 '_log_collector_instead_of_running')
-    @mock.patch('performanceplatform.collector.main._run_collector')
     @mock.patch('performanceplatform.collector.arguments.parse_args')
     @mock.patch('performanceplatform.utils.collector.get_config')
     def test_collectors_can_be_disabled(self,
                                         mock_get_config,
                                         mock_parse_args,
-                                        mock_run_collector,
                                         mock_log_collector_instead_of_running):
         orig_disable_collectors = os.getenv('DISABLE_COLLECTORS')
         mock_parse_args.return_value = Namespace(
@@ -64,17 +62,8 @@ class TestMain(unittest.TestCase):
             console_logging=True,
         )
         try:
-            os.environ['DISABLE_COLLECTORS'] = 'false'
-            main.main()
-            assert mock_run_collector.called
-            assert not mock_log_collector_instead_of_running.called
-
-            mock_run_collector.reset_mock()
-            mock_log_collector_instead_of_running.reset_mock()
-
             os.environ['DISABLE_COLLECTORS'] = 'true'
             main.main()
-            assert not mock_run_collector.called
             assert mock_log_collector_instead_of_running.called
         finally:
             if orig_disable_collectors:


### PR DESCRIPTION
Provide the facility for an application that imports performanceplatform-collector (e.g. Stagecraft) to output collector logs (JSON and non-JSON formats) to a filename and location of its choice, rather than to /log/production.*.
This has been achieved by extending the _run_collector method to support two new arguments: logfile_path and logfile_name.

Story: https://www.pivotaltracker.com/story/show/105753440