### PR TITLE
Rotate logfiles

### DIFF
--- a/performanceplatform/collector/__init__.py
+++ b/performanceplatform/collector/__init__.py
@@ -2,6 +2,6 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 __author__ = "GDS Developers"
 __author_email__ = "performance@digital.cabinet-office.gov.uk"

--- a/performanceplatform/collector/logging_setup.py
+++ b/performanceplatform/collector/logging_setup.py
@@ -1,19 +1,22 @@
 from logstash_formatter import LogstashFormatter
 import logging
+from logging.handlers import RotatingFileHandler
 import os
 import sys
 import traceback
 
 
 def get_log_file_handler(path):
-    handler = logging.FileHandler(path)
+    handler = RotatingFileHandler(
+        path, maxBytes=2 * 1024 * 1024 * 1024, backupCount=1)
     handler.setFormatter(logging.Formatter(
         "%(asctime)s [%(levelname)s] -> %(message)s"))
     return handler
 
 
 def get_json_log_handler(path, app_name, json_fields):
-    handler = logging.FileHandler(path)
+    handler = RotatingFileHandler(
+        path, maxBytes=2 * 1024 * 1024 * 1024, backupCount=1)
     formatter = LogstashFormatter()
     formatter.defaults['@tags'] = ['collector', app_name]
     formatter.defaults['@fields'] = json_fields


### PR DESCRIPTION
Rotate log files (2 * 2GB files for JSON and non-JSON logs) to overcome file size issue in production.

Currently the log files are quickly reaching 40GB in size, which is causing a file write error and stalled processing of collector jobs (jobs left sitting in Rabbit MQ).

Story: https://www.pivotaltracker.com/story/show/107201116