### PR TITLE
Concurrent log handler

### DIFF
--- a/performanceplatform/collector/__init__.py
+++ b/performanceplatform/collector/__init__.py
@@ -2,6 +2,6 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
-__version__ = "0.2.6"
+__version__ = "0.2.7"
 __author__ = "GDS Developers"
 __author_email__ = "performance@digital.cabinet-office.gov.uk"

--- a/performanceplatform/collector/logging_setup.py
+++ b/performanceplatform/collector/logging_setup.py
@@ -1,22 +1,22 @@
 from logstash_formatter import LogstashFormatter
 import logging
-from logging.handlers import RotatingFileHandler
+from cloghandler import ConcurrentRotatingFileHandler
 import os
 import sys
 import traceback
 
 
 def get_log_file_handler(path):
-    handler = RotatingFileHandler(
-        path, maxBytes=2 * 1024 * 1024 * 1024, backupCount=1)
+    handler = ConcurrentRotatingFileHandler(
+        path, "a", 2 * 1024 * 1024 * 1024, 1)
     handler.setFormatter(logging.Formatter(
         "%(asctime)s [%(levelname)s] -> %(message)s"))
     return handler
 
 
 def get_json_log_handler(path, app_name, json_fields):
-    handler = RotatingFileHandler(
-        path, maxBytes=2 * 1024 * 1024 * 1024, backupCount=1)
+    handler = ConcurrentRotatingFileHandler(
+        path, "a", 2 * 1024 * 1024 * 1024, 1)
     formatter = LogstashFormatter()
     formatter.defaults['@tags'] = ['collector', app_name]
     formatter.defaults['@fields'] = json_fields

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ requests>=1.2.0
 statsd==3.0
 mock==1.0.1
 performanceplatform-client==0.11.1
+ConcurrentLogHandler==0.9.1


### PR DESCRIPTION
Switch to ConcurrentLogHandler library in an attempt to overcome an issue with Celery not cleaning up log files on production due to its incompatibility with Python's RotatingFileHandler.