### PR TITLE
Close down logging

### DIFF
--- a/performanceplatform/collector/__init__.py
+++ b/performanceplatform/collector/__init__.py
@@ -2,6 +2,6 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
-__version__ = "0.2.7"
+__version__ = "0.2.8"
 __author__ = "GDS Developers"
 __author_email__ = "performance@digital.cabinet-office.gov.uk"

--- a/performanceplatform/collector/logging_setup.py
+++ b/performanceplatform/collector/logging_setup.py
@@ -55,6 +55,14 @@ def set_up_logging(
     logger.info("{0} logging started".format(app_name))
 
 
+def close_down_logging():
+    logger = logging.getLogger()
+    handlers = logger.handlers[:]
+    for handler in handlers:
+        handler.close()
+        logger.removeHandler(handler)
+
+
 def extra_fields_from_exception(exception):
     """Exception into a dict to be passed to logger
 

--- a/performanceplatform/collector/main.py
+++ b/performanceplatform/collector/main.py
@@ -5,7 +5,8 @@ import importlib
 from collections import OrderedDict
 
 from performanceplatform.collector import arguments
-from performanceplatform.collector.logging_setup import set_up_logging
+from performanceplatform.collector.logging_setup import (
+    set_up_logging, close_down_logging)
 from performanceplatform.utils.collector import get_config
 
 
@@ -117,6 +118,8 @@ def _run_collector(entrypoint, args, logfile_path=None, logfile_name=None):
             args.start_at,
             args.end_at
         )
+        if not args.console_logging:
+            close_down_logging()
 
 
 def main():


### PR DESCRIPTION
When collectors are run in production via Celery, file descriptors for the JSON and non-JSON log handlers are not being removed when a job has completed. This is an attempt to resolve this by closing and removing all handlers on completion of a job.