### PR TITLE
Fix ga credentials script

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -210,7 +210,7 @@ The following steps will enable you to generate the credentials files that you w
   - Choose **Application type** > "Other".
   - Enter a name. Again, the name can be anything
   - Once created click the download button. This will download a JSON file containing your client secrets.
-  - To generate the storage path you run ``python tools/generate-ga-credentials.py path/to/client/secrets.json`` where secrets.json is the JSON file downloaded in the previous step.
+  - To generate the storage path, run ``python tools/generate-ga-credentials.py path/to/client/secrets.json`` in your VM, where secrets.json is the JSON file downloaded in the previous step.
 
     + The script will output a link to follow in Google accounts. Following the link to with generate an authorization code
     + Copy and paste the authorization code back into the CLI at the prompt.

--- a/performanceplatform/collector/__init__.py
+++ b/performanceplatform/collector/__init__.py
@@ -2,6 +2,6 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
-__version__ = "0.2.9"
+__version__ = "0.3.0"
 __author__ = "GDS Developers"
 __author_email__ = "performance@digital.cabinet-office.gov.uk"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pytz==2013d
 argparse
 python-dateutil
 logstash_formatter
-gapy==1.3.3
+gapy==1.3.4
 lxml>=3.2.0
 dshelpers>=1.0.4
 unicodecsv

--- a/requirements_for_tests.txt
+++ b/requirements_for_tests.txt
@@ -1,6 +1,6 @@
 PyHamcrest
 nose
 mock
-pep8==1.6.2
+pep8==1.7.0
 coverage
 freezegun

--- a/tools/generate-ga-credentials.py
+++ b/tools/generate-ga-credentials.py
@@ -17,8 +17,9 @@ import json
 from os.path import abspath, exists as path_exists
 from os import makedirs
 
+from oauth2client import tools
+
 from gapy.client import from_secrets_file
-import oauth2client.tools
 
 
 def copy_json(input_path, output_path):
@@ -30,18 +31,16 @@ def copy_json(input_path, output_path):
                 indent=2)
 
 
-def generate_google_credentials(client_secret):
-    # Prevent oauth2client from trying to open a browser
-    # This is run from inside the VM so there is no browser
-    oauth2client.tools.FLAGS.auth_local_webserver = False
-
+def generate_google_credentials(args):
+    client_secret = args.client_secret
     if not path_exists(abspath("./creds/ga/")):
         makedirs("./creds/ga")
     storage_path = abspath("./creds/ga/storage.db")
     secret_path = abspath("./creds/ga/client_secret.json")
     from_secrets_file(
         client_secret,
-        storage_path=storage_path)
+        storage_path=storage_path,
+        flags=args)
 
     copy_json(client_secret, secret_path)
 
@@ -56,7 +55,8 @@ def generate_google_credentials(client_secret):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description=__doc__,
-        formatter_class=argparse.RawTextHelpFormatter)
+        formatter_class=argparse.RawTextHelpFormatter,
+        parents=[tools.argparser])
 
     parser.add_argument(
         'client_secret',
@@ -64,4 +64,8 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    generate_google_credentials(args.client_secret)
+    # This script is run from within the VM so
+    # disable need for a browser
+    args.noauth_local_webserver = True
+
+    generate_google_credentials(args)


### PR DESCRIPTION
Google's oauth2client library now requires that command line flags are passed to its run_flow method via a mandatory 'flags' argument.

Use this flags argument (via a call to the gapy library's from_secrets_file method) to prevent oauth2client from opening a browser when running the generate-ga-credentials script.