### PR TITLE
Allow ga trending collector to handle missing data.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   allow_failures:
     - python: "3.4"
 install:
-  - "pip install . --use-mirrors"
+  - "pip install ."
 script: ./run_tests.sh
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   allow_failures:
     - python: "3.4"
 install:
-  - "pip install ."
+  - "pip install . --process-dependency-links"
 script: ./run_tests.sh
 env:
   global:

--- a/performanceplatform/collector/ga/trending.py
+++ b/performanceplatform/collector/ga/trending.py
@@ -81,7 +81,10 @@ def sum_data(data, metric, collapse_key, dates, floor):
         if dimensions['pagePath'] in collapsed[k]['pagePath']:
             collapsed[k]['pagePath'] = dimensions['pagePath']
 
-        collapsed[k][week] += int(row['metrics'][metric])
+        m = row['metrics'].get(metric, 0)
+        if not m:
+            m = 0
+        collapsed[k][week] += int(m)
 
     for key in collapsed:
         for week in ['week1', 'week2']:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,6 @@ unicodecsv
 requests>=1.2.0
 statsd==3.0
 mock==1.0.1
-performanceplatform-client==0.11.3
+#performanceplatform-client==0.11.3
+http://github.com/alphagov/performanceplatform-client/tarball/master
 ConcurrentLogHandler==0.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,12 @@ argparse
 python-dateutil
 logstash_formatter
 oauth2client==1.5.2
-gapy==1.3.5
+gapy==1.3.6
 lxml>=3.2.0
 dshelpers>=1.0.4
 unicodecsv
 requests>=1.2.0
 statsd==3.0
 mock==1.0.1
-#performanceplatform-client==0.11.3
-http://github.com/alphagov/performanceplatform-client/tarball/master#egg=performanceplatform-client
+performanceplatform-client==0.11.5
 ConcurrentLogHandler==0.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ requests>=1.2.0
 statsd==3.0
 mock==1.0.1
 #performanceplatform-client==0.11.3
-http://github.com/alphagov/performanceplatform-client/tarball/master
+http://github.com/alphagov/performanceplatform-client/tarball/master#egg=performanceplatform-client
 ConcurrentLogHandler==0.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pyasn1==0.4.2
 pytz==2013d
 argparse
 python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,18 @@ def _get_requirements(fname):
     """
     packages = _read(fname).split('\n')
     packages = (p.strip() for p in packages)
-    packages = (p for p in packages if p and not p.startswith('#'))
+    packages = (p for p in packages if p and not p.startswith('#') and
+                not p.startswith('http'))
+    return list(packages)
+
+
+def _get_dependency_links(fname):
+    """
+    Create a list of github urls from the requirements file
+    """
+    packages = _read(fname).split('\n')
+    packages = (p.strip() for p in packages)
+    packages = (p for p in packages if p and p.startswith('http'))
     return list(packages)
 
 
@@ -72,6 +83,7 @@ if __name__ == '__main__':
         license='MIT',
         keywords='api data performance_platform',
 
+        dependency_links=_get_dependency_links('requirements.txt'),
         install_requires=_get_requirements('requirements.txt'),
         tests_require=_get_requirements('requirements_for_tests.txt'),
 

--- a/tests/performanceplatform/collector/ga/test_trending.py
+++ b/tests/performanceplatform/collector/ga/test_trending.py
@@ -12,6 +12,71 @@ from performanceplatform.collector.ga.trending import encode_id, get_date, \
     parse_query, query_ga
 
 
+class test_data_calculations_bad_data(unittest.TestCase):
+
+    collapse_key = 'pageTitle'
+    metric = 'pageviews'
+    floor = 500
+
+    data_1 = [{'metrics': {u'pageviews': u'1000'},
+             'dimensions': {u'pagePath': u'/foo/page1',
+                            u'pageTitle': u'foo',
+                            u'day': u'29',
+                            u'month': u'01',
+                            u'year': u'2014'}},
+              {'metrics': {u'pageviews': u''},
+               'dimensions': {u'pagePath': u'/foo/page1',
+                              u'pageTitle': u'foo',
+                              u'day': u'31',
+                              u'month': u'01',
+                              u'year': u'2014'}}]
+
+    data_2 = [{'metrics': {u'pageviews': u'1000'},
+             'dimensions': {u'pagePath': u'/foo/page1',
+                            u'pageTitle': u'foo',
+                            u'day': u'29',
+                            u'month': u'01',
+                            u'year': u'2014'}},
+              {'metrics': {u'pageviews': None},
+               'dimensions': {u'pagePath': u'/foo/page1',
+                              u'pageTitle': u'foo',
+                              u'day': u'31',
+                              u'month': u'01',
+                              u'year': u'2014'}}]
+
+    data_3 = [{'metrics': {u'pageviews': u'1000'},
+             'dimensions': {u'pagePath': u'/foo/page1',
+                            u'pageTitle': u'foo',
+                            u'day': u'29',
+                            u'month': u'01',
+                            u'year': u'2014'}}]
+
+    data_4 = [{'metrics': {u'pageviews': u'600'},
+               'dimensions': {u'pagePath': u'/foo/page1',
+                              u'pageTitle': u'foo',
+                              u'day': u'31',
+                              u'month': u'01',
+                              u'year': u'2014'}}]
+
+    data_5 = [{'metrics': {},
+               'dimensions': {u'pagePath': u'/foo/page1',
+                              u'pageTitle': u'foo',
+                              u'day': u'31',
+                              u'month': u'01',
+                              u'year': u'2014'}}]
+
+    @freeze_time("2014-02-12 01:00:00")
+    def test_sum_by_day_with_floor(self):
+
+        dates = get_date()
+
+        for src in [self.data_1, self.data_2, self.data_3, self.data_4,
+                    self.data_5]:
+            collapsed_data = sum_data(src, self.metric, self.collapse_key,
+                                      dates, self.floor)
+            self.assertEqual(len(collapsed_data), 1)
+
+
 class test_data_calculations(unittest.TestCase):
 
     collapse_key = 'pageTitle'

--- a/tests/performanceplatform/collector/ga/test_trending.py
+++ b/tests/performanceplatform/collector/ga/test_trending.py
@@ -19,11 +19,11 @@ class test_data_calculations_bad_data(unittest.TestCase):
     floor = 500
 
     data_1 = [{'metrics': {u'pageviews': u'1000'},
-             'dimensions': {u'pagePath': u'/foo/page1',
-                            u'pageTitle': u'foo',
-                            u'day': u'29',
-                            u'month': u'01',
-                            u'year': u'2014'}},
+              'dimensions': {u'pagePath': u'/foo/page1',
+                             u'pageTitle': u'foo',
+                             u'day': u'29',
+                             u'month': u'01',
+                             u'year': u'2014'}},
               {'metrics': {u'pageviews': u''},
                'dimensions': {u'pagePath': u'/foo/page1',
                               u'pageTitle': u'foo',
@@ -32,11 +32,11 @@ class test_data_calculations_bad_data(unittest.TestCase):
                               u'year': u'2014'}}]
 
     data_2 = [{'metrics': {u'pageviews': u'1000'},
-             'dimensions': {u'pagePath': u'/foo/page1',
-                            u'pageTitle': u'foo',
-                            u'day': u'29',
-                            u'month': u'01',
-                            u'year': u'2014'}},
+              'dimensions': {u'pagePath': u'/foo/page1',
+                             u'pageTitle': u'foo',
+                             u'day': u'29',
+                             u'month': u'01',
+                             u'year': u'2014'}},
               {'metrics': {u'pageviews': None},
                'dimensions': {u'pagePath': u'/foo/page1',
                               u'pageTitle': u'foo',
@@ -45,11 +45,11 @@ class test_data_calculations_bad_data(unittest.TestCase):
                               u'year': u'2014'}}]
 
     data_3 = [{'metrics': {u'pageviews': u'1000'},
-             'dimensions': {u'pagePath': u'/foo/page1',
-                            u'pageTitle': u'foo',
-                            u'day': u'29',
-                            u'month': u'01',
-                            u'year': u'2014'}}]
+              'dimensions': {u'pagePath': u'/foo/page1',
+                             u'pageTitle': u'foo',
+                             u'day': u'29',
+                             u'month': u'01',
+                             u'year': u'2014'}}]
 
     data_4 = [{'metrics': {u'pageviews': u'600'},
                'dimensions': {u'pagePath': u'/foo/page1',
@@ -70,7 +70,10 @@ class test_data_calculations_bad_data(unittest.TestCase):
 
         dates = get_date()
 
-        for src in [self.data_1, self.data_2, self.data_3, self.data_4,
+        for src in [self.data_1,
+                    self.data_2,
+                    self.data_3,
+                    self.data_4,
                     self.data_5]:
             collapsed_data = sum_data(src, self.metric, self.collapse_key,
                                       dates, self.floor)


### PR DESCRIPTION
In cases where there are not 2 weeks worth of data, errors were thrown
when trying to parse the metrics that were required to calculate the %
change.

This now handles that case, but will unfortunately set the missing weeks
data to the floor.  This will ensure that there is some data available
although it will not be 100% accurate.