### PR TITLE
[159467985] Multi-user pingdom

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   allow_failures:
     - python: "3.4"
 install:
-  - "pip install . --use-mirrors"
+  - "pip install . --process-dependency-links"
 script: ./run_tests.sh
 env:
   global:

--- a/performanceplatform/collector/__init__.py
+++ b/performanceplatform/collector/__init__.py
@@ -2,6 +2,6 @@
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 __author__ = "GDS Developers"
 __author_email__ = "performance@digital.cabinet-office.gov.uk"

--- a/performanceplatform/collector/pingdom/core.py
+++ b/performanceplatform/collector/pingdom/core.py
@@ -12,6 +12,7 @@ class Pingdom(object):
         self.user = config['user']
         self.password = config['password']
         self.app_key = config['app_key']
+        self.account_email = config['account_email']
         self.API_LOCATION = "https://api.pingdom.com/api/2.0/"
 
     def _make_request(self, path, url_params=None):
@@ -21,7 +22,8 @@ class Pingdom(object):
             url=self.API_LOCATION + path,
             auth=(self.user, self.password),
             headers={
-                "App-Key": self.app_key
+                "App-Key": self.app_key,
+                "Account-Email": self.account_email
             },
             params=url_params
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,12 +3,12 @@ argparse
 python-dateutil
 logstash_formatter
 oauth2client==1.5.2
-gapy==1.3.5
+gapy==1.3.6
 lxml>=3.2.0
 dshelpers>=1.0.4
 unicodecsv
 requests>=1.2.0
 statsd==3.0
 mock==1.0.1
-performanceplatform-client==0.11.3
+performanceplatform-client==0.11.5
 ConcurrentLogHandler==0.9.1

--- a/tests/performanceplatform/collector/pingdom/test_pingdom_api.py
+++ b/tests/performanceplatform/collector/pingdom/test_pingdom_api.py
@@ -17,7 +17,8 @@ class TestPingdomApi(unittest.TestCase):
         self.config = {
             "user": "foo@bar.com",
             "password": "secret",
-            "app_key": "12345"
+            "app_key": "12345",
+            "account_email": "foo@bar.com"
         }
 
     def test_init_from_config(self):


### PR DESCRIPTION
We have moved to using the GaaP pingdom account, which is using
multi-user Pingdom.

In order to make requests to the Pingdom API for multi-user accounts we
must pass the header 'Account-Email', the value of which is
'gaap-billing@digital.cabinet-office.gov.uk'.

- Bump the version to 0.3.2
- Get the header from the config
- Pass the header to Pingdom

solo @tlwr